### PR TITLE
Standardize pageTitle usage

### DIFF
--- a/DC/404.php
+++ b/DC/404.php
@@ -1,7 +1,7 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "404 | Page not found");
-	include $base . '/includes/header.php';
+$pageTitle = '404 | Page not found - Dating Contact';
+include $base . '/includes/header.php';
 ?>
 
 <div class="container">

--- a/DC/cookie-policy.php
+++ b/DC/cookie-policy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Cookiebeleid');
 $canonical = 'https://datingcontact.co.uk/cookie-policy';
 $pageTitle = 'Cookie Policy | ';
 include $base . '/includes/header.php';

--- a/DC/datingtips.php
+++ b/DC/datingtips.php
@@ -1,9 +1,8 @@
 <?php 
-$base = __DIR__;
-define("TITLE", "Dating Tips");
 
-$canonical = 'https://datingcontact.co.uk/datingtips';
+$base = __DIR__;
 $pageTitle = 'Dating Tips - Dating Contact';
+$canonical = 'https://datingcontact.co.uk/datingtips';
 
 include $base . '/includes/array_tips.php';
 

--- a/DC/includes/header.php
+++ b/DC/includes/header.php
@@ -13,7 +13,7 @@
       $config['PROFILE_ENDPOINT'],
       'date-with',
       $canonical ?? null,
-      $pageTitle ?? (defined('TITLE') ? TITLE : null),
+      $pageTitle ?? null,
       $companyName
   );
 ?>
@@ -51,7 +51,7 @@
         $config['PROFILE_ENDPOINT'],
         'date-with',
         $canonical ?? null,
-        $pageTitle ?? (defined('TITLE') ? TITLE : null),
+        $pageTitle ?? null,
         $companyName
     );
     echo '<link rel="canonical" href="' . $canonicalUrl . '" >';

--- a/DC/index.php
+++ b/DC/index.php
@@ -1,6 +1,6 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Home");
+$pageTitle = 'Home - Dating Contact';
 include $base . '/includes/header.php';
 ?>
 <div class="container">

--- a/DC/partnerlinks.php
+++ b/DC/partnerlinks.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Partnerlinks');
 $canonical = 'https://datingcontact.co.uk/partnerlinks';
 $pageTitle = 'Partnerlinks - Dating Contact';
 include $base . '/includes/header.php';

--- a/DC/privacy.php
+++ b/DC/privacy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Privacy Policy');
 $canonical = 'https://datingcontact.co.uk/privacy';
 $pageTitle = 'Privacy Policy - Dating Contact';
 include $base . '/includes/header.php';

--- a/DC/profile.php
+++ b/DC/profile.php
@@ -1,6 +1,6 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Daten");
+$pageTitle = 'Daten - Dating Contact';
 // Determine the referrer ID from the environment if provided
 $ref_id = getenv('REF_ID') ?: '';
 include $base . '/includes/header.php';

--- a/DN/404.php
+++ b/DN/404.php
@@ -1,7 +1,7 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "404 | Page not found");
-	include $base . '/includes/header.php';
+$pageTitle = '404 | Page not found - Dating Nebenan';
+include $base . '/includes/header.php';
 ?>
 
 <div class="container">

--- a/DN/cookie-policy.php
+++ b/DN/cookie-policy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Cookie-Richtlinie');
 $canonical = 'https://datingnebenan.de/cookie-policy';
 $pageTitle = 'Cookie-Richtlinie | ';
 include $base . '/includes/header.php';

--- a/DN/datingtips.php
+++ b/DN/datingtips.php
@@ -1,9 +1,7 @@
 <?php 
 $base = __DIR__;
-define("TITLE", "Datingtipps");
-
-$canonical = 'https://datingnebenan.de/datingtips';
 $pageTitle = 'Datingtipps - Dating Nebenan';
+$canonical = 'https://datingnebenan.de/datingtips';
 
 include $base . '/includes/array_tips.php';
 

--- a/DN/includes/header.php
+++ b/DN/includes/header.php
@@ -16,7 +16,7 @@
       $config['PROFILE_ENDPOINT'],
       'date-mit',
       $canonical ?? null,
-      $pageTitle ?? (defined('TITLE') ? TITLE : null),
+      $pageTitle ?? null,
       $companyName
   );
 ?>
@@ -55,7 +55,7 @@
         $config['PROFILE_ENDPOINT'],
         'date-mit',
         $canonical ?? null,
-        $pageTitle ?? (defined('TITLE') ? TITLE : null),
+        $pageTitle ?? null,
         $companyName
     );
     echo '<link rel="canonical" href="' . $canonicalUrl . '" >';

--- a/DN/index.php
+++ b/DN/index.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Home");
 include $base . '/includes/array_prov.php';
 $pageTitle = 'Dating Nebenan – Finde Liebe Direkt Um Die Ecke';
 include $base . '/includes/header.php';

--- a/DN/land.php
+++ b/DN/land.php
@@ -31,7 +31,7 @@
 
     $metaDescription = isset($landInfo['meta']) ? $landInfo['meta'] : '';
 
-    define('TITLE', 'Dating ' . $landTitle);
+    $pageTitle = 'Dating ' . $landTitle . ' - Dating Nebenan';
     $base = __DIR__;
     include $base . '/includes/header.php';
 ?>

--- a/DN/partnerlinks.php
+++ b/DN/partnerlinks.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Partnerlinks');
 $canonical = 'https://datingnebenan.de/partnerlinks';
 $pageTitle = 'Partnerlinks - Dating Nebenan';
 include $base . '/includes/header.php';

--- a/DN/privacy.php
+++ b/DN/privacy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Datenschutzerklärung');
 $canonical = 'https://datingnebenan.de/privacy';
 $pageTitle = 'Privacy Policy - Dating Nebenan';
 include $base . '/includes/header.php';

--- a/DN/profile.php
+++ b/DN/profile.php
@@ -1,6 +1,6 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Daten");
+$pageTitle = 'Daten - Dating Nebenan';
 // Determine the referrer ID from the environment if provided
 $ref_id = getenv('REF_ID') ?: '';
 include $base . '/includes/header.php';

--- a/ONL/404.php
+++ b/ONL/404.php
@@ -1,7 +1,7 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "404 | Page not found");
-	include $base . '/includes/header.php';
+$pageTitle = '404 | Page not found - Oproepjes Nederland';
+include $base . '/includes/header.php';
 ?>
 
 <div class="container">

--- a/ONL/cookie-policy.php
+++ b/ONL/cookie-policy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Cookiebeleid');
 $canonical = 'https://oproepjesnederland.nl/cookie-policy';
 $pageTitle = 'Cookiebeleid | ';
 include $base . '/includes/header.php';

--- a/ONL/datingtips.php
+++ b/ONL/datingtips.php
@@ -1,9 +1,7 @@
 <?php 
 $base = __DIR__;
-define("TITLE", "Datingtips");
-
-$canonical = 'https://oproepjesnederland.nl/datingtips';
 $pageTitle = 'Datingtips - Oproepjes Nederland';
+$canonical = 'https://oproepjesnederland.nl/datingtips';
 
 include $base . '/includes/array_tips.php';
 

--- a/ONL/includes/header.php
+++ b/ONL/includes/header.php
@@ -13,7 +13,7 @@
       $config['PROFILE_ENDPOINT'],
       'daten-met',
       $canonical ?? null,
-      $pageTitle ?? (defined('TITLE') ? TITLE : null),
+      $pageTitle ?? null,
       $companyName
   );
 ?>
@@ -51,7 +51,7 @@
         $config['PROFILE_ENDPOINT'],
         'daten-met',
         $canonical ?? null,
-        $pageTitle ?? (defined('TITLE') ? TITLE : null),
+        $pageTitle ?? null,
         $companyName
     );
     echo '<link rel="canonical" href="' . $canonicalUrl . '" >';

--- a/ONL/index.php
+++ b/ONL/index.php
@@ -1,6 +1,6 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Home");
+$pageTitle = 'Home - Oproepjes Nederland';
 include $base . '/includes/header.php';
 ?>
 <div class="container">

--- a/ONL/partnerlinks.php
+++ b/ONL/partnerlinks.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Partnerlinks');
 $canonical = 'https://oproepjesnederland.nl/partnerlinks';
 $pageTitle = 'Partnerlinks - Oproepjes Nederland';
 include $base . '/includes/header.php';

--- a/ONL/privacy.php
+++ b/ONL/privacy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Privacybeleid');
 $canonical = 'https://oproepjesnederland.nl/privacy';
 $pageTitle = 'Privacybeleid - Oproepjes Nederland';
 include $base . '/includes/header.php';

--- a/ONL/profile.php
+++ b/ONL/profile.php
@@ -1,6 +1,6 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Daten");
+$pageTitle = 'Daten - Oproepjes Nederland';
 // Determine the referrer ID from the environment if provided
 $ref_id = getenv('REF_ID') ?: '';
 include $base . '/includes/header.php';

--- a/ZB/404.php
+++ b/ZB/404.php
@@ -1,7 +1,7 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "404 | Page not found");
-	include $base . '/includes/header.php';
+$pageTitle = '404 | Page not found - Zoekertjes België';
+include $base . '/includes/header.php';
 ?>
 
 <div class="container">

--- a/ZB/cookie-policy.php
+++ b/ZB/cookie-policy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Cookiebeleid');
 $canonical = 'https://zoekertjesbelgie.be/cookie-policy';
 $pageTitle = 'Cookiebeleid | ';
 include $base . '/includes/header.php';

--- a/ZB/datingtips.php
+++ b/ZB/datingtips.php
@@ -1,9 +1,7 @@
 <?php 
 $base = __DIR__;
-define("TITLE", "Datingtips");
-
-$canonical = 'https://zoekertjesbelgie.be/datingtips';
 $pageTitle = 'Datingtips - Zoekertjes België';
+$canonical = 'https://zoekertjesbelgie.be/datingtips';
 
 include $base . '/includes/array_tips.php';
 

--- a/ZB/includes/header.php
+++ b/ZB/includes/header.php
@@ -13,7 +13,7 @@
       $config['PROFILE_ENDPOINT'],
       'daten-met',
       $canonical ?? null,
-      $pageTitle ?? (defined('TITLE') ? TITLE : null),
+      $pageTitle ?? null,
       $companyName
   );
 ?>
@@ -52,7 +52,7 @@
         $config['PROFILE_ENDPOINT'],
         'daten-met',
         $canonical ?? null,
-        $pageTitle ?? (defined('TITLE') ? TITLE : null),
+        $pageTitle ?? null,
         $companyName
     );
     echo '<link rel="canonical" href="' . $canonicalUrl . '" >';

--- a/ZB/index.php
+++ b/ZB/index.php
@@ -1,6 +1,6 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Home");
+$pageTitle = 'Home - Zoekertjes België';
 include $base . '/includes/header.php';
 ?>
 <div class="container">

--- a/ZB/partnerlinks.php
+++ b/ZB/partnerlinks.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Partnerlinks');
 $canonical = 'https://zoekertjesbelgie.be/partnerlinks';
 $pageTitle = 'Partnerlinks - Zoekertjes België';
 include $base . '/includes/header.php';

--- a/ZB/privacy.php
+++ b/ZB/privacy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Privacybeleid');
 $canonical = 'https://zoekertjesbelgie.be/privacy';
 $pageTitle = 'Privacybeleid - Zoekertjes België';
 include $base . '/includes/header.php';

--- a/ZB/profile.php
+++ b/ZB/profile.php
@@ -1,6 +1,6 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Daten");
+$pageTitle = 'Daten - Zoekertjes België';
 // Determine the referrer ID from the environment if provided
 $ref_id = getenv('REF_ID') ?: '';
 include $base . '/includes/header.php';


### PR DESCRIPTION
## Summary
- use `$pageTitle` for headers
- remove `define('TITLE', ...)` constants
- update individual page titles

## Testing
- `php -l DC/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653be313d08324bd5f71ef164c67ca