### PR TITLE
Centralize helper utilities

### DIFF
--- a/DC/datingtips.php
+++ b/DC/datingtips.php
@@ -6,7 +6,7 @@ $canonical = 'https://datingcontact.co.uk/datingtips';
 
 include $base . '/includes/array_tips.php';
 
-require_once $base . '/includes/utils.php';
+require_once $base . '/../includes/utils.php';
 
 $datingtip = 'datingtips';
 if(isset($_GET['item'])) {

--- a/DC/includes/utils.php
+++ b/DC/includes/utils.php
@@ -1,8 +1,0 @@
-<?php
-
-function strip_bad_chars($input) {
-  $output = preg_replace('/[^a-zA-Z0-9_-]/', '', $input);
-  return $output;
-}
-
-?>

--- a/DC/provincie.php
+++ b/DC/provincie.php
@@ -1,7 +1,7 @@
 <?php
   $base = __DIR__;
   include $base . '/includes/array_prov.php';
-  include $base . '/includes/utils.php';
+  require_once $base . '/../includes/utils.php';
 
   $zoek = null;
   if (isset($_GET['item'])) {

--- a/DN/datingtips.php
+++ b/DN/datingtips.php
@@ -5,7 +5,7 @@ $canonical = 'https://datingnebenan.de/datingtips';
 
 include $base . '/includes/array_tips.php';
 
-require_once $base . '/includes/utils.php';
+require_once $base . '/../includes/utils.php';
 
 $param = $_GET['tip'] ?? $_GET['item'] ?? null;
 $tipSlug = null;

--- a/DN/generate_sitemap.php
+++ b/DN/generate_sitemap.php
@@ -5,11 +5,7 @@ $config = include __DIR__ . '/config.php';
 
 $baseUrl = getenv('ONL_BASE_URL') ?: 'https://datingnebenan.de';
 
-function slugify($text) {
-    $text = strtolower(trim($text));
-    $text = preg_replace('/[^a-z0-9]+/', '-', $text);
-    return trim($text, '-');
-}
+require_once __DIR__ . '/../includes/utils.php';
 
 $urls = [];
 

--- a/DN/includes/utils.php
+++ b/DN/includes/utils.php
@@ -1,8 +1,0 @@
-<?php
-
-function strip_bad_chars($input) {
-  $output = preg_replace('/[^a-zA-Z0-9_-]/', '', $input);
-  return $output;
-}
-
-?>

--- a/DN/land.php
+++ b/DN/land.php
@@ -1,6 +1,6 @@
 <?php
     include('includes/array_prov.php');
-    include('includes/utils.php');
+    require_once __DIR__ . '/../includes/utils.php';
 
     $land = isset($_GET['land']) ? strip_bad_chars($_GET['land']) : '';
     switch ($land) {

--- a/DN/provincie.php
+++ b/DN/provincie.php
@@ -1,7 +1,7 @@
 <?php
   $base = __DIR__;
   include $base . '/includes/array_prov.php';
-  include $base . '/includes/utils.php';
+  require_once $base . '/../includes/utils.php';
 
         $country = '';
         if(isset($_GET['item'])) {

--- a/ONL/datingtips.php
+++ b/ONL/datingtips.php
@@ -5,7 +5,7 @@ $canonical = 'https://oproepjesnederland.nl/datingtips';
 
 include $base . '/includes/array_tips.php';
 
-require_once $base . '/includes/utils.php';
+require_once $base . '/../includes/utils.php';
 
 $datingtip = 'datingtips';
 if(isset($_GET['item'])) {

--- a/ONL/includes/utils.php
+++ b/ONL/includes/utils.php
@@ -1,8 +1,0 @@
-<?php
-
-function strip_bad_chars($input) {
-  $output = preg_replace('/[^a-zA-Z0-9_-]/', '', $input);
-  return $output;
-}
-
-?>

--- a/ONL/provincie.php
+++ b/ONL/provincie.php
@@ -1,7 +1,7 @@
 <?php
   $base = __DIR__;
   include $base . '/includes/array_prov.php';
-  include $base . '/includes/utils.php';
+  require_once $base . '/../includes/utils.php';
 
   $zoek = null;
   if (isset($_GET['item'])) {

--- a/ZB/datingtips.php
+++ b/ZB/datingtips.php
@@ -5,7 +5,7 @@ $canonical = 'https://zoekertjesbelgie.be/datingtips';
 
 include $base . '/includes/array_tips.php';
 
-require_once $base . '/includes/utils.php';
+require_once $base . '/../includes/utils.php';
 
 $datingtip = 'datingtips';
 if(isset($_GET['item'])) {

--- a/ZB/includes/utils.php
+++ b/ZB/includes/utils.php
@@ -1,8 +1,0 @@
-<?php
-
-function strip_bad_chars($input) {
-  $output = preg_replace('/[^a-zA-Z0-9_-]/', '', $input);
-  return $output;
-}
-
-?>

--- a/ZB/provincie.php
+++ b/ZB/provincie.php
@@ -1,7 +1,7 @@
 <?php
   $base = __DIR__;
   include $base . '/includes/array_prov.php';
-  include $base . '/includes/utils.php';
+  require_once $base . '/../includes/utils.php';
 
   $zoek = null;
   if (isset($_GET['item'])) {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1,0 +1,12 @@
+<?php
+function slugify(string $text): string {
+    $text = strtolower(trim($text));
+    $text = preg_replace('/[^a-z0-9]+/', '-', $text);
+    return trim($text, '-');
+}
+
+function strip_bad_chars($input) {
+    $output = preg_replace('/[^a-zA-Z0-9_-]/', '', $input);
+    return $output;
+}
+?>

--- a/lib/site.php
+++ b/lib/site.php
@@ -2,6 +2,7 @@
 /**
  * Common utilities for site headers.
  */
+require_once __DIR__ . '/../includes/utils.php';
 function get_base_url(string $default): string {
     $url = getenv('ONL_BASE_URL');
     return $url !== false && $url !== '' ? $url : $default;
@@ -17,12 +18,6 @@ function configure_error_handling(): void {
         ini_set('display_errors', '0');
         ini_set('display_startup_errors', '0');
     }
-}
-
-function slugify(string $text): string {
-    $text = strtolower(trim($text));
-    $text = preg_replace('/[^a-z0-9]+/', '-', $text);
-    return trim($text, '-');
 }
 
 function generate_canonical(string $baseUrl, string $apiEndpoint, string $slugPrefix, ?string $overrideUrl, ?string $titleOverride, string $siteName): array {


### PR DESCRIPTION
## Summary
- introduce `includes/utils.php` with `slugify()` and `strip_bad_chars()`
- remove duplicate utility files
- update pages to include the new shared utilities
- load utilities from `lib/site.php`
- use shared utilities in sitemap generator

## Testing
- `php -l lib/site.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865415f9bc08324a20c05950394a81a