### PR TITLE
Fix cookie banner script paths

### DIFF
--- a/DC/includes/footer.php
+++ b/DC/includes/footer.php
@@ -28,11 +28,11 @@
 </div>
 </main>
 </div> <!-- /.oproepjes -->
-<script src="js/vendor/vue.2.5.13.min.js"></script>
-<script src="js/vendor/axios.0.17.1.min.js"></script>
-<script src="js/vendor/jquery.min.js"></script>
-<script src="js/vendor/bootstrap.bundle.min.js"></script>
-<script src="js/cookie-consent.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/vue.2.5.13.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/axios.0.17.1.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/jquery.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/bootstrap.bundle.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/cookie-consent.js"></script>
 <script type="text/javascript">
   var topper = ['1.jpg', '2.jpg', '3.jpg', '4.jpg', '5.jpg', '6.jpg', '7.jpg', '8.jpg', '9.jpg', '10.jpg'];
   $('<a href="https://testars-consin.icu/543064f4-6080-4845-8f43-30f049426cdf?site={DC}"><img class="align-center" src="img/banners/' + topper[Math.floor(Math.random() * topper.length)] + '" alt="Exciting places to connect"></a>').appendTo('#top-banner');

--- a/DN/includes/footer.php
+++ b/DN/includes/footer.php
@@ -28,11 +28,11 @@
 </div>
 </main>
 </div> <!-- /.oproepjes -->
-<script src="js/vendor/vue.2.5.13.min.js"></script>
-<script src="js/vendor/axios.0.17.1.min.js"></script>
-<script src="js/vendor/jquery.min.js"></script>
-<script src="js/vendor/bootstrap.bundle.min.js"></script>
-<script src="js/cookie-consent.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/vue.2.5.13.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/axios.0.17.1.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/jquery.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/bootstrap.bundle.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/cookie-consent.js"></script>
 <script type="text/javascript">
   var topper = ['1.jpg', '2.jpg', '3.jpg', '4.jpg', '5.jpg', '6.jpg', '7.jpg', '8.jpg', '9.jpg', '10.jpg'];
   $('<a href="https://testars-consin.icu/543064f4-6080-4845-8f43-30f049426cdf?site={DN}" target="_blank" rel="nofollow noopener"><img class="align-center" src="img/banners/' + topper[Math.floor(Math.random() * topper.length)] + '" alt="Spannende Orte für Kontakte"></a>').appendTo('#top-banner');

--- a/ONL/includes/footer.php
+++ b/ONL/includes/footer.php
@@ -28,11 +28,11 @@
 </div>
 </main>
 </div> <!-- /.oproepjes -->
-<script src="js/vendor/vue.2.5.13.min.js"></script>
-<script src="js/vendor/axios.0.17.1.min.js"></script>
-<script src="js/vendor/jquery.min.js"></script>
-<script src="js/vendor/bootstrap.bundle.min.js"></script>
-<script src="js/cookie-consent.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/vue.2.5.13.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/axios.0.17.1.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/jquery.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/bootstrap.bundle.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/cookie-consent.js"></script>
 <script type="text/javascript">
 	var topper = ['1.gif', '2.gif', '3.gif', '4.gif', '5.gif', '6.gif', '7.gif', '8.gif', '9.gif', '10.gif'];
 	$('<a href="https://testars-consin.icu/543064f4-6080-4845-8f43-30f049426cdf?site={ONL}"><img class="align-center" src="img/banners/' + topper[Math.floor(Math.random() * topper.length)] + '" alt="Spannende plekken om contact te maken"></a>').appendTo('#top-banner');

--- a/ZB/includes/footer.php
+++ b/ZB/includes/footer.php
@@ -28,11 +28,11 @@
 </div>
 </main>
 </div> <!-- /.oproepjes -->
-<script src="js/vendor/vue.2.5.13.min.js"></script>
-<script src="js/vendor/axios.0.17.1.min.js"></script>
-<script src="js/vendor/jquery.min.js"></script>
-<script src="js/vendor/bootstrap.bundle.min.js"></script>
-<script src="js/cookie-consent.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/vue.2.5.13.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/axios.0.17.1.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/jquery.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/vendor/bootstrap.bundle.min.js"></script>
+<script src="<?php echo $baseUrl; ?>/js/cookie-consent.js"></script>
 <script type="text/javascript">
   var topper = ['1.gif', '2.gif', '3.gif', '4.gif', '5.gif', '6.gif', '7.gif', '8.gif', '9.gif', '10.gif'];
   $('<a href="https://testars-consin.icu/543064f4-6080-4845-8f43-30f049426cdf?site={ZB}"><img class="align-center" src="img/banners/' + topper[Math.floor(Math.random() * topper.length)] + '" alt="Spannende plekken om contact te maken"></a>').appendTo('#top-banner');


### PR DESCRIPTION
## Summary
- load JS assets using absolute URLs based on `$baseUrl`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865494d68348324b6c920e0f79c32c3