### PR TITLE
Fix includes path for site utilities

### DIFF
--- a/DC/datingtips.php
+++ b/DC/datingtips.php
@@ -6,7 +6,7 @@ $canonical = 'https://datingcontact.co.uk/datingtips';
 
 include $base . '/includes/array_tips.php';
 
-require_once $base . '/../includes/utils.php';
+require_once $base . '/includes/utils.php';
 
 $datingtip = 'datingtips';
 if(isset($_GET['item'])) {

--- a/DC/includes/header.php
+++ b/DC/includes/header.php
@@ -3,7 +3,7 @@
     if (!isset($base)) {
     $base = dirname(__DIR__);
   }
-  require_once $base . '/../includes/site.php';
+  require_once $base . '/includes/site.php';
   include $base . '/includes/nav_items.php';
   // Config is required for API lookups when rendering profile pages
   // Capture the returned configuration array for later use

--- a/DC/includes/site.php
+++ b/DC/includes/site.php
@@ -2,7 +2,7 @@
 /**
  * Common utilities for site headers.
  */
-require_once __DIR__ . '/../includes/utils.php';
+require_once __DIR__ . '/utils.php';
 function get_base_url(string $default): string {
     $url = getenv('ONL_BASE_URL');
     return $url !== false && $url !== '' ? $url : $default;

--- a/DC/provincie.php
+++ b/DC/provincie.php
@@ -1,7 +1,7 @@
 <?php
   $base = __DIR__;
   include $base . '/includes/array_prov.php';
-  require_once $base . '/../includes/utils.php';
+  require_once $base . '/includes/utils.php';
 
   $zoek = null;
   if (isset($_GET['item'])) {

--- a/DN/datingtips.php
+++ b/DN/datingtips.php
@@ -5,7 +5,7 @@ $canonical = 'https://datingnebenan.de/datingtips';
 
 include $base . '/includes/array_tips.php';
 
-require_once $base . '/../includes/utils.php';
+require_once $base . '/includes/utils.php';
 
 $param = $_GET['tip'] ?? $_GET['item'] ?? null;
 $tipSlug = null;

--- a/DN/generate_sitemap.php
+++ b/DN/generate_sitemap.php
@@ -5,7 +5,7 @@ $config = include __DIR__ . '/includes/config.php';
 
 $baseUrl = getenv('ONL_BASE_URL') ?: 'https://datingnebenan.de';
 
-require_once __DIR__ . '/../includes/utils.php';
+require_once __DIR__ . '/includes/utils.php';
 
 $urls = [];
 

--- a/DN/includes/header.php
+++ b/DN/includes/header.php
@@ -3,7 +3,7 @@
     if (!isset($base)) {
     $base = dirname(__DIR__);
   }
-  require_once $base . '/../includes/site.php';
+  require_once $base . '/includes/site.php';
   include $base . '/includes/nav_items.php';
   // Config is required for API lookups when rendering profile pages
   // Capture the returned configuration array for later use

--- a/DN/includes/site.php
+++ b/DN/includes/site.php
@@ -2,7 +2,7 @@
 /**
  * Common utilities for site headers.
  */
-require_once __DIR__ . '/../includes/utils.php';
+require_once __DIR__ . '/utils.php';
 function get_base_url(string $default): string {
     $url = getenv('ONL_BASE_URL');
     return $url !== false && $url !== '' ? $url : $default;

--- a/DN/land.php
+++ b/DN/land.php
@@ -1,6 +1,6 @@
 <?php
     include('includes/array_prov.php');
-    require_once __DIR__ . '/../includes/utils.php';
+    require_once __DIR__ . '/includes/utils.php';
 
     $land = isset($_GET['land']) ? strip_bad_chars($_GET['land']) : '';
     switch ($land) {

--- a/DN/provincie.php
+++ b/DN/provincie.php
@@ -1,7 +1,7 @@
 <?php
   $base = __DIR__;
   include $base . '/includes/array_prov.php';
-  require_once $base . '/../includes/utils.php';
+  require_once $base . '/includes/utils.php';
 
         $country = '';
         if(isset($_GET['item'])) {

--- a/ONL/datingtips.php
+++ b/ONL/datingtips.php
@@ -5,7 +5,7 @@ $canonical = 'https://oproepjesnederland.nl/datingtips';
 
 include $base . '/includes/array_tips.php';
 
-require_once $base . '/../includes/utils.php';
+require_once $base . '/includes/utils.php';
 
 $datingtip = 'datingtips';
 if(isset($_GET['item'])) {

--- a/ONL/includes/header.php
+++ b/ONL/includes/header.php
@@ -3,7 +3,7 @@
     if (!isset($base)) {
     $base = dirname(__DIR__);
   }
-  require_once $base . '/../includes/site.php';
+  require_once $base . '/includes/site.php';
   include $base . '/includes/nav_items.php';
   // Config is required for API lookups when rendering profile pages
   // Capture the returned configuration array for later use

--- a/ONL/includes/site.php
+++ b/ONL/includes/site.php
@@ -2,7 +2,7 @@
 /**
  * Common utilities for site headers.
  */
-require_once __DIR__ . '/../includes/utils.php';
+require_once __DIR__ . '/utils.php';
 function get_base_url(string $default): string {
     $url = getenv('ONL_BASE_URL');
     return $url !== false && $url !== '' ? $url : $default;

--- a/ONL/provincie.php
+++ b/ONL/provincie.php
@@ -1,7 +1,7 @@
 <?php
   $base = __DIR__;
   include $base . '/includes/array_prov.php';
-  require_once $base . '/../includes/utils.php';
+  require_once $base . '/includes/utils.php';
 
   $zoek = null;
   if (isset($_GET['item'])) {

--- a/ZB/datingtips.php
+++ b/ZB/datingtips.php
@@ -5,7 +5,7 @@ $canonical = 'https://zoekertjesbelgie.be/datingtips';
 
 include $base . '/includes/array_tips.php';
 
-require_once $base . '/../includes/utils.php';
+require_once $base . '/includes/utils.php';
 
 $datingtip = 'datingtips';
 if(isset($_GET['item'])) {

--- a/ZB/includes/header.php
+++ b/ZB/includes/header.php
@@ -3,7 +3,7 @@
     if (!isset($base)) {
     $base = dirname(__DIR__);
   }
-  require_once $base . '/../includes/site.php';
+  require_once $base . '/includes/site.php';
   include $base . '/includes/nav_items.php';
   // Config is required for API lookups when rendering profile pages
   // Capture the returned configuration array for later use

--- a/ZB/includes/site.php
+++ b/ZB/includes/site.php
@@ -2,7 +2,7 @@
 /**
  * Common utilities for site headers.
  */
-require_once __DIR__ . '/../includes/utils.php';
+require_once __DIR__ . '/utils.php';
 function get_base_url(string $default): string {
     $url = getenv('ONL_BASE_URL');
     return $url !== false && $url !== '' ? $url : $default;

--- a/ZB/provincie.php
+++ b/ZB/provincie.php
@@ -1,7 +1,7 @@
 <?php
   $base = __DIR__;
   include $base . '/includes/array_prov.php';
-  require_once $base . '/../includes/utils.php';
+  require_once $base . '/includes/utils.php';
 
   $zoek = null;
   if (isset($_GET['item'])) {


### PR DESCRIPTION
## Summary
- update site files to include their own `includes/` directory
- point `site.php` to utilities without parent paths

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865836f11588324bd6fcc7aa85b85cc