### PR TITLE
Ensure profile ID stays in URL

### DIFF
--- a/DC/js/profile.js
+++ b/DC/js/profile.js
@@ -74,13 +74,13 @@ var profiel= new Vue({
                     }
                     var slug = slugify(that.profile.name || '');
                     if(slug){
-                        var newUrl = '/date-with-' + slug;
+                        var slugUrl = '/date-with-' + slug;
                         var link = document.querySelector('link[rel=canonical]');
                         if(link){
-                            link.setAttribute('href', 'https://datingcontact.co.uk' + newUrl);
+                            link.setAttribute('href', 'https://datingcontact.co.uk' + slugUrl);
                         }
                         document.title = 'Date ' + that.profile.name;
-                        history.replaceState({}, '', newUrl);
+                        history.replaceState({}, '', slugUrl + '?id=' + that.profile_id);
                     }
                 })
                 .catch(function (error) {

--- a/ONL/js/profile.js
+++ b/ONL/js/profile.js
@@ -74,13 +74,13 @@ var profiel= new Vue({
                     }
                     var slug = slugify(that.profile.name || '');
                     if(slug){
-                        var newUrl = '/daten-met-' + slug;
+                        var slugUrl = '/daten-met-' + slug;
                         var link = document.querySelector('link[rel=canonical]');
                         if(link){
-                            link.setAttribute('href', 'https://oproepjesnederland.nl' + newUrl);
+                            link.setAttribute('href', 'https://oproepjesnederland.nl' + slugUrl);
                         }
                         document.title = 'Date ' + that.profile.name;
-                        history.replaceState({}, '', newUrl);
+                        history.replaceState({}, '', slugUrl + '?id=' + that.profile_id);
                     }
                 })
                 .catch(function (error) {

--- a/ZB/js/profile.js
+++ b/ZB/js/profile.js
@@ -74,13 +74,13 @@ var profiel= new Vue({
                     }
                     var slug = slugify(that.profile.name || '');
                     if(slug){
-                        var newUrl = '/daten-met-' + slug;
+                        var slugUrl = '/daten-met-' + slug;
                         var link = document.querySelector('link[rel=canonical]');
                         if(link){
-                            link.setAttribute('href', 'https://zoekertjesbelgie.be' + newUrl);
+                            link.setAttribute('href', 'https://zoekertjesbelgie.be' + slugUrl);
                         }
                         document.title = 'Date ' + that.profile.name;
-                        history.replaceState({}, '', newUrl);
+                        history.replaceState({}, '', slugUrl + '?id=' + that.profile_id);
                     }
                 })
                 .catch(function (error) {


### PR DESCRIPTION
## Summary
- keep the profile id in the URL after loading a profile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865905dba0c83248cc02e81f0affb51