### PR TITLE
Fix dating tips link and slug

### DIFF
--- a/DC/datingtips.php
+++ b/DC/datingtips.php
@@ -8,9 +8,10 @@ include $base . '/includes/array_tips.php';
 
 require_once $base . '/includes/utils.php';
 
-$datingtip = 'datingtips';
-if(isset($_GET['item'])) {
-        $candidate = strip_bad_chars($_GET['item']);
+$datingtip = 'dating-tips';
+$param = $_GET['tip'] ?? $_GET['item'] ?? null;
+if ($param !== null) {
+        $candidate = strip_bad_chars($param);
         if (isset($datingtips[$candidate])) {
                 $datingtip = $candidate;
         }

--- a/DC/includes/nav_items.php
+++ b/DC/includes/nav_items.php
@@ -55,7 +55,7 @@
 	$navItems2 = array(
 
                                         array(
-                                                'slug' => 'datingtips.php',
+                                                'slug' => 'datingtips',
                                                 'title' => 'Dating tips'
                                         ),
                                         array(

--- a/DC/sitemap.xml
+++ b/DC/sitemap.xml
@@ -71,7 +71,7 @@ http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://datingcontact.co.uk/datingtips.php</loc>
+    <loc>https://datingcontact.co.uk/datingtips</loc>
     <lastmod>2025-06-12</lastmod>
     <priority>0.80</priority>
   </url>


### PR DESCRIPTION
## Summary
- fix navigation slug so `Dating tips` links to `/datingtips`
- handle `tip` and `item` parameters in `datingtips.php`
- update sitemap to reference `/datingtips`

## Testing
- `php -l DC/datingtips.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686592ecc7308324a1b9852590f1d34d