### PR TITLE
Add sitemap generation to all sites

### DIFF
--- a/DC/generate_sitemap.php
+++ b/DC/generate_sitemap.php
@@ -1,0 +1,63 @@
+<?php
+require __DIR__ . '/includes/array_prov.php';
+require __DIR__ . '/includes/array_tips.php';
+$config = include __DIR__ . '/includes/config.php';
+
+$baseUrl = getenv('ONL_BASE_URL') ?: 'https://datingcontact.co.uk';
+
+require_once __DIR__ . '/includes/utils.php';
+
+$urls = [];
+
+$static = [
+    '/',
+    '/datingtips',
+    '/partnerlinks',
+    '/privacy',
+    '/cookie-policy',
+];
+foreach ($static as $path) {
+    $urls[] = $baseUrl . $path;
+}
+
+foreach (array_keys($provincies) as $slug) {
+    $urls[] = $baseUrl . "/dating-" . $slug;
+}
+foreach (array_keys($datingtips) as $slug) {
+    $urls[] = $baseUrl . "/datingtips-" . $slug;
+}
+
+$provinceApiBase = rtrim($config['BASE_API_URL'], '/') . '/profile/province';
+$countryMap = [ 'uk' => $provincies ];
+$profilePaths = [];
+foreach ($countryMap as $code => $provArr) {
+    foreach ($provArr as $prov) {
+        $endpoint = $provinceApiBase . '/' . $code . '/' . rawurlencode($prov['name']) . '/120';
+        $json = @file_get_contents($endpoint);
+        if ($json === false) continue;
+        $data = json_decode($json, true);
+        if (!$data || !isset($data['profiles'])) continue;
+        foreach ($data['profiles'] as $prof) {
+            if (empty($prof['id']) || empty($prof['name'])) continue;
+            $slug = slugify($prof['name']);
+            $profilePaths[$prof['id']] = $baseUrl . '/date-with-' . $slug . '?id=' . $prof['id'];
+        }
+    }
+}
+foreach ($profilePaths as $url) {
+    $urls[] = $url;
+}
+
+$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
+$xml->addAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+$xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+$xml->addAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd');
+$lastMod = date('c');
+foreach ($urls as $loc) {
+    $url = $xml->addChild('url');
+    $url->addChild('loc', htmlspecialchars($loc, ENT_XML1));
+    $url->addChild('lastmod', $lastMod);
+}
+file_put_contents(__DIR__ . '/sitemap.xml', $xml->asXML());
+
+echo "Generated sitemap with " . count($urls) . " URLs\n";

--- a/ONL/generate_sitemap.php
+++ b/ONL/generate_sitemap.php
@@ -1,0 +1,63 @@
+<?php
+require __DIR__ . '/includes/array_prov.php';
+require __DIR__ . '/includes/array_tips.php';
+$config = include __DIR__ . '/includes/config.php';
+
+$baseUrl = getenv('ONL_BASE_URL') ?: 'https://oproepjesnederland.nl';
+
+require_once __DIR__ . '/includes/utils.php';
+
+$urls = [];
+
+$static = [
+    '/',
+    '/datingtips',
+    '/partnerlinks',
+    '/privacy',
+    '/cookie-policy',
+];
+foreach ($static as $path) {
+    $urls[] = $baseUrl . $path;
+}
+
+foreach (array_keys($provincies) as $slug) {
+    $urls[] = $baseUrl . "/dating-" . $slug;
+}
+foreach (array_keys($datingtips) as $slug) {
+    $urls[] = $baseUrl . "/datingtips-" . $slug;
+}
+
+$provinceApiBase = rtrim($config['BASE_API_URL'], '/') . '/profile/province';
+$countryMap = [ 'nl' => $provincies ];
+$profilePaths = [];
+foreach ($countryMap as $code => $provArr) {
+    foreach ($provArr as $prov) {
+        $endpoint = $provinceApiBase . '/' . $code . '/' . rawurlencode($prov['name']) . '/120';
+        $json = @file_get_contents($endpoint);
+        if ($json === false) continue;
+        $data = json_decode($json, true);
+        if (!$data || !isset($data['profiles'])) continue;
+        foreach ($data['profiles'] as $prof) {
+            if (empty($prof['id']) || empty($prof['name'])) continue;
+            $slug = slugify($prof['name']);
+            $profilePaths[$prof['id']] = $baseUrl . '/daten-met-' . $slug . '?id=' . $prof['id'];
+        }
+    }
+}
+foreach ($profilePaths as $url) {
+    $urls[] = $url;
+}
+
+$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
+$xml->addAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+$xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+$xml->addAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd');
+$lastMod = date('c');
+foreach ($urls as $loc) {
+    $url = $xml->addChild('url');
+    $url->addChild('loc', htmlspecialchars($loc, ENT_XML1));
+    $url->addChild('lastmod', $lastMod);
+}
+file_put_contents(__DIR__ . '/sitemap.xml', $xml->asXML());
+
+echo "Generated sitemap with " . count($urls) . " URLs\n";

--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ Deployment for each site relies on three environment variables that override the
 
 If not set, each site falls back to the hard coded values in its own `config.php`. Specifying these variables per environment lets the same code run for all four directories (`DC`, `DN`, `ONL`, `ZB`).
 
+
+## Generating sitemaps
+
+Run `php generate_sitemap.php` inside any site directory (`DC`, `DN`, `ONL`, `ZB`) to rebuild its `sitemap.xml` file. You can automate this with a cron job to keep search indexes fresh.
+

--- a/ZB/generate_sitemap.php
+++ b/ZB/generate_sitemap.php
@@ -1,0 +1,63 @@
+<?php
+require __DIR__ . '/includes/array_prov.php';
+require __DIR__ . '/includes/array_tips.php';
+$config = include __DIR__ . '/includes/config.php';
+
+$baseUrl = getenv('ONL_BASE_URL') ?: 'https://zoekertjesbelgie.be';
+
+require_once __DIR__ . '/includes/utils.php';
+
+$urls = [];
+
+$static = [
+    '/',
+    '/datingtips',
+    '/partnerlinks',
+    '/privacy',
+    '/cookie-policy',
+];
+foreach ($static as $path) {
+    $urls[] = $baseUrl . $path;
+}
+
+foreach (array_keys($provincies) as $slug) {
+    $urls[] = $baseUrl . "/dating-" . $slug;
+}
+foreach (array_keys($datingtips) as $slug) {
+    $urls[] = $baseUrl . "/datingtips-" . $slug;
+}
+
+$provinceApiBase = rtrim($config['BASE_API_URL'], '/') . '/profile/province';
+$countryMap = [ 'be' => $provincies ];
+$profilePaths = [];
+foreach ($countryMap as $code => $provArr) {
+    foreach ($provArr as $prov) {
+        $endpoint = $provinceApiBase . '/' . $code . '/' . rawurlencode($prov['name']) . '/120';
+        $json = @file_get_contents($endpoint);
+        if ($json === false) continue;
+        $data = json_decode($json, true);
+        if (!$data || !isset($data['profiles'])) continue;
+        foreach ($data['profiles'] as $prof) {
+            if (empty($prof['id']) || empty($prof['name'])) continue;
+            $slug = slugify($prof['name']);
+            $profilePaths[$prof['id']] = $baseUrl . '/daten-met-' . $slug . '?id=' . $prof['id'];
+        }
+    }
+}
+foreach ($profilePaths as $url) {
+    $urls[] = $url;
+}
+
+$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
+$xml->addAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+$xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+$xml->addAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd');
+$lastMod = date('c');
+foreach ($urls as $loc) {
+    $url = $xml->addChild('url');
+    $url->addChild('loc', htmlspecialchars($loc, ENT_XML1));
+    $url->addChild('lastmod', $lastMod);
+}
+file_put_contents(__DIR__ . '/sitemap.xml', $xml->asXML());
+
+echo "Generated sitemap with " . count($urls) . " URLs\n";


### PR DESCRIPTION
## Summary
- add `generate_sitemap.php` to DC, ONL and ZB
- set each file's base URL and province data
- pull profile data with the correct country codes and profile slug path
- document sitemap generation in the README

## Testing
- `php -l DC/generate_sitemap.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68663686eb188324bd4dd2f398f2cb69