### PR TITLE
Append new URLs when generating sitemaps

### DIFF
--- a/DC/generate_sitemap.php
+++ b/DC/generate_sitemap.php
@@ -6,6 +6,7 @@ $config = include __DIR__ . '/includes/config.php';
 $baseUrl = getenv('ONL_BASE_URL') ?: 'https://datingcontact.co.uk';
 
 require_once __DIR__ . '/includes/utils.php';
+require_once __DIR__ . '/includes/sitemap.php';
 
 $urls = [];
 
@@ -48,16 +49,5 @@ foreach ($profilePaths as $url) {
     $urls[] = $url;
 }
 
-$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
-$xml->addAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-$xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-$xml->addAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd');
-$lastMod = date('c');
-foreach ($urls as $loc) {
-    $url = $xml->addChild('url');
-    $url->addChild('loc', htmlspecialchars($loc, ENT_XML1));
-    $url->addChild('lastmod', $lastMod);
-}
-file_put_contents(__DIR__ . '/sitemap.xml', $xml->asXML());
-
-echo "Generated sitemap with " . count($urls) . " URLs\n";
+$added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
+echo "Added $added new URLs to sitemap\n";

--- a/DC/includes/sitemap.php
+++ b/DC/includes/sitemap.php
@@ -1,0 +1,39 @@
+<?php
+function merge_into_sitemap(array $urls, string $sitemapPath): int {
+    $namespace = 'http://www.sitemaps.org/schemas/sitemap/0.9';
+    $existing = [];
+    $xml = null;
+    if (file_exists($sitemapPath)) {
+        $xml = simplexml_load_file($sitemapPath);
+        if ($xml !== false) {
+            $xml->registerXPathNamespace('sm', $namespace);
+            foreach ($xml->xpath('//sm:url') as $node) {
+                $locNode = $node->xpath('sm:loc');
+                if ($locNode) {
+                    $existing[(string)$locNode[0]] = $node;
+                }
+            }
+        } else {
+            $xml = null;
+        }
+    }
+    if ($xml === null) {
+        $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
+        $xml->addAttribute('xmlns', $namespace);
+        $xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $xml->addAttribute('xsi:schemaLocation', $namespace . ' ' . $namespace . '/sitemap.xsd');
+    }
+    $lastMod = date('c');
+    $added = 0;
+    foreach ($urls as $loc) {
+        if (!isset($existing[$loc])) {
+            $url = $xml->addChild('url', null, $namespace);
+            $url->addChild('loc', htmlspecialchars($loc, ENT_XML1), $namespace);
+            $url->addChild('lastmod', $lastMod, $namespace);
+            $added++;
+        }
+    }
+    file_put_contents($sitemapPath, $xml->asXML());
+    return $added;
+}
+?>

--- a/DN/generate_sitemap.php
+++ b/DN/generate_sitemap.php
@@ -6,6 +6,7 @@ $config = include __DIR__ . '/includes/config.php';
 $baseUrl = getenv('ONL_BASE_URL') ?: 'https://datingnebenan.de';
 
 require_once __DIR__ . '/includes/utils.php';
+require_once __DIR__ . '/includes/sitemap.php';
 
 $urls = [];
 
@@ -57,16 +58,5 @@ foreach ($profilePaths as $url) {
     $urls[] = $url;
 }
 
-$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
-$xml->addAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-$xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-$xml->addAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd');
-$lastMod = date('c');
-foreach ($urls as $loc) {
-    $url = $xml->addChild('url');
-    $url->addChild('loc', htmlspecialchars($loc, ENT_XML1));
-    $url->addChild('lastmod', $lastMod);
-}
-file_put_contents(__DIR__ . '/sitemap.xml', $xml->asXML());
-
-echo "Generated sitemap with " . count($urls) . " URLs\n";
+$added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
+echo "Added $added new URLs to sitemap\n";

--- a/DN/includes/sitemap.php
+++ b/DN/includes/sitemap.php
@@ -1,0 +1,39 @@
+<?php
+function merge_into_sitemap(array $urls, string $sitemapPath): int {
+    $namespace = 'http://www.sitemaps.org/schemas/sitemap/0.9';
+    $existing = [];
+    $xml = null;
+    if (file_exists($sitemapPath)) {
+        $xml = simplexml_load_file($sitemapPath);
+        if ($xml !== false) {
+            $xml->registerXPathNamespace('sm', $namespace);
+            foreach ($xml->xpath('//sm:url') as $node) {
+                $locNode = $node->xpath('sm:loc');
+                if ($locNode) {
+                    $existing[(string)$locNode[0]] = $node;
+                }
+            }
+        } else {
+            $xml = null;
+        }
+    }
+    if ($xml === null) {
+        $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
+        $xml->addAttribute('xmlns', $namespace);
+        $xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $xml->addAttribute('xsi:schemaLocation', $namespace . ' ' . $namespace . '/sitemap.xsd');
+    }
+    $lastMod = date('c');
+    $added = 0;
+    foreach ($urls as $loc) {
+        if (!isset($existing[$loc])) {
+            $url = $xml->addChild('url', null, $namespace);
+            $url->addChild('loc', htmlspecialchars($loc, ENT_XML1), $namespace);
+            $url->addChild('lastmod', $lastMod, $namespace);
+            $added++;
+        }
+    }
+    file_put_contents($sitemapPath, $xml->asXML());
+    return $added;
+}
+?>

--- a/ONL/generate_sitemap.php
+++ b/ONL/generate_sitemap.php
@@ -6,6 +6,7 @@ $config = include __DIR__ . '/includes/config.php';
 $baseUrl = getenv('ONL_BASE_URL') ?: 'https://oproepjesnederland.nl';
 
 require_once __DIR__ . '/includes/utils.php';
+require_once __DIR__ . '/includes/sitemap.php';
 
 $urls = [];
 
@@ -48,16 +49,5 @@ foreach ($profilePaths as $url) {
     $urls[] = $url;
 }
 
-$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
-$xml->addAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-$xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-$xml->addAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd');
-$lastMod = date('c');
-foreach ($urls as $loc) {
-    $url = $xml->addChild('url');
-    $url->addChild('loc', htmlspecialchars($loc, ENT_XML1));
-    $url->addChild('lastmod', $lastMod);
-}
-file_put_contents(__DIR__ . '/sitemap.xml', $xml->asXML());
-
-echo "Generated sitemap with " . count($urls) . " URLs\n";
+$added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
+echo "Added $added new URLs to sitemap\n";

--- a/ONL/includes/sitemap.php
+++ b/ONL/includes/sitemap.php
@@ -1,0 +1,39 @@
+<?php
+function merge_into_sitemap(array $urls, string $sitemapPath): int {
+    $namespace = 'http://www.sitemaps.org/schemas/sitemap/0.9';
+    $existing = [];
+    $xml = null;
+    if (file_exists($sitemapPath)) {
+        $xml = simplexml_load_file($sitemapPath);
+        if ($xml !== false) {
+            $xml->registerXPathNamespace('sm', $namespace);
+            foreach ($xml->xpath('//sm:url') as $node) {
+                $locNode = $node->xpath('sm:loc');
+                if ($locNode) {
+                    $existing[(string)$locNode[0]] = $node;
+                }
+            }
+        } else {
+            $xml = null;
+        }
+    }
+    if ($xml === null) {
+        $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
+        $xml->addAttribute('xmlns', $namespace);
+        $xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $xml->addAttribute('xsi:schemaLocation', $namespace . ' ' . $namespace . '/sitemap.xsd');
+    }
+    $lastMod = date('c');
+    $added = 0;
+    foreach ($urls as $loc) {
+        if (!isset($existing[$loc])) {
+            $url = $xml->addChild('url', null, $namespace);
+            $url->addChild('loc', htmlspecialchars($loc, ENT_XML1), $namespace);
+            $url->addChild('lastmod', $lastMod, $namespace);
+            $added++;
+        }
+    }
+    file_put_contents($sitemapPath, $xml->asXML());
+    return $added;
+}
+?>

--- a/ZB/generate_sitemap.php
+++ b/ZB/generate_sitemap.php
@@ -6,6 +6,7 @@ $config = include __DIR__ . '/includes/config.php';
 $baseUrl = getenv('ONL_BASE_URL') ?: 'https://zoekertjesbelgie.be';
 
 require_once __DIR__ . '/includes/utils.php';
+require_once __DIR__ . '/includes/sitemap.php';
 
 $urls = [];
 
@@ -48,16 +49,5 @@ foreach ($profilePaths as $url) {
     $urls[] = $url;
 }
 
-$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
-$xml->addAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-$xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-$xml->addAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd');
-$lastMod = date('c');
-foreach ($urls as $loc) {
-    $url = $xml->addChild('url');
-    $url->addChild('loc', htmlspecialchars($loc, ENT_XML1));
-    $url->addChild('lastmod', $lastMod);
-}
-file_put_contents(__DIR__ . '/sitemap.xml', $xml->asXML());
-
-echo "Generated sitemap with " . count($urls) . " URLs\n";
+$added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
+echo "Added $added new URLs to sitemap\n";

--- a/ZB/includes/sitemap.php
+++ b/ZB/includes/sitemap.php
@@ -1,0 +1,39 @@
+<?php
+function merge_into_sitemap(array $urls, string $sitemapPath): int {
+    $namespace = 'http://www.sitemaps.org/schemas/sitemap/0.9';
+    $existing = [];
+    $xml = null;
+    if (file_exists($sitemapPath)) {
+        $xml = simplexml_load_file($sitemapPath);
+        if ($xml !== false) {
+            $xml->registerXPathNamespace('sm', $namespace);
+            foreach ($xml->xpath('//sm:url') as $node) {
+                $locNode = $node->xpath('sm:loc');
+                if ($locNode) {
+                    $existing[(string)$locNode[0]] = $node;
+                }
+            }
+        } else {
+            $xml = null;
+        }
+    }
+    if ($xml === null) {
+        $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
+        $xml->addAttribute('xmlns', $namespace);
+        $xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $xml->addAttribute('xsi:schemaLocation', $namespace . ' ' . $namespace . '/sitemap.xsd');
+    }
+    $lastMod = date('c');
+    $added = 0;
+    foreach ($urls as $loc) {
+        if (!isset($existing[$loc])) {
+            $url = $xml->addChild('url', null, $namespace);
+            $url->addChild('loc', htmlspecialchars($loc, ENT_XML1), $namespace);
+            $url->addChild('lastmod', $lastMod, $namespace);
+            $added++;
+        }
+    }
+    file_put_contents($sitemapPath, $xml->asXML());
+    return $added;
+}
+?>


### PR DESCRIPTION
## Summary
- add shared `merge_into_sitemap` helper
- call helper from each site's `generate_sitemap.php`

## Testing
- `php -l DC/generate_sitemap.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663a54968c83249be5cb7c7423cf9e