### PR TITLE
Load tips on homepage

### DIFF
--- a/DC/index.php
+++ b/DC/index.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = 'Dating Contact: Dating Advertenties UK';
+include $base . '/includes/array_tips.php';
 include $base . '/includes/header.php';
 ?>
 <div class="container">

--- a/DN/index.php
+++ b/DN/index.php
@@ -2,6 +2,7 @@
 $base = __DIR__;
 include $base . '/includes/array_prov.php';
 $pageTitle = 'Dating Nebenan – Finde Liebe Direkt Um Die Ecke';
+include $base . '/includes/array_tips.php';
 include $base . '/includes/header.php';
 ?>
 <div class="container">

--- a/ONL/index.php
+++ b/ONL/index.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = 'Home - Oproepjes Nederland';
+include $base . '/includes/array_tips.php';
 include $base . '/includes/header.php';
 ?>
 <div class="container">

--- a/ZB/index.php
+++ b/ZB/index.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = 'Home - Zoekertjes België';
+include $base . '/includes/array_tips.php';
 include $base . '/includes/header.php';
 ?>
 <div class="container">


### PR DESCRIPTION
## Summary
- include `array_tips.php` before loading header templates on all homepages

## Testing
- `php -l DC/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686640e0ee10832489b2aab56758c734