### PR TITLE
Fix navigation dropdown for DN

### DIFF
--- a/DN/includes/header.php
+++ b/DN/includes/header.php
@@ -5,6 +5,8 @@
   }
   require_once $base . '/includes/site.php';
   include $base . '/includes/nav_items.php';
+  // Load datingtips for navigation dropdown
+  require_once $base . '/includes/array_tips.php';
   // Config is required for API lookups when rendering profile pages
   // Capture the returned configuration array for later use
   $config = include $base . '/includes/config.php';

--- a/DN/includes/nav.php
+++ b/DN/includes/nav.php
@@ -5,9 +5,6 @@
             <a class="nav-link" href="<?php echo $land['slug']; ?>"><?php echo $land['title']; ?></a>
         </li>
 <?php } ?>
-    <li class="nav-item">
-        <a class="nav-link" href="/datingtips">Datingtipps</a>
-    </li>
     <!-- Datingtips links -->
     <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle drpdwn" href="#" id="navbarDropdownTips" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Datingtipps</a>


### PR DESCRIPTION
## Summary
- remove duplicate Datingtipps link from navigation
- always load tips array for dropdown

## Testing
- `php` not installed; could not run syntax checks

------
https://chatgpt.com/codex/tasks/task_e_686646da65608324b7fe7d50a4132404