### PR TITLE
Adjust province loops

### DIFF
--- a/DC/includes/header.php
+++ b/DC/includes/header.php
@@ -9,6 +9,8 @@
   if (file_exists($base . '/includes/array_prov.php')) {
       include $base . '/includes/array_prov.php';
   }
+  // Expected province lists for this site
+  $provinceLists = ['provincies'];
   // Config is required for API lookups when rendering profile pages
   // Capture the returned configuration array for later use
   $config = include $base . '/includes/config.php';
@@ -65,7 +67,7 @@
     $og_image = $default_image;
     $og_url = $canonicalUrl;
     $og_pages = [];
-    foreach (['provincies', 'de', 'at', 'ch'] as $listName) {
+    foreach (['provincies'] as $listName) {
         if (isset($$listName) && is_array($$listName)) {
             foreach ($$listName as $slug => $data) {
                 $og_pages['dating-' . $slug] = [

--- a/DN/includes/header.php
+++ b/DN/includes/header.php
@@ -10,6 +10,8 @@
   if (file_exists($base . '/includes/array_prov.php')) {
       include $base . '/includes/array_prov.php';
   }
+  // Expected province lists for this site
+  $provinceLists = ['provincies', 'de', 'at', 'ch'];
   // Config is required for API lookups when rendering profile pages
   // Capture the returned configuration array for later use
   $config = include $base . '/includes/config.php';

--- a/ONL/includes/header.php
+++ b/ONL/includes/header.php
@@ -8,6 +8,8 @@
   if (file_exists($base . '/includes/array_prov.php')) {
       include $base . '/includes/array_prov.php';
   }
+  // Expected province lists for this site
+  $provinceLists = ['provincies'];
   // Config is required for API lookups when rendering profile pages
   // Capture the returned configuration array for later use
   $config = include $base . '/includes/config.php';
@@ -64,7 +66,7 @@
     $og_image = $default_image;
     $og_url = $default_url;
     $og_pages = [];
-    foreach (['provincies', 'de', 'at', 'ch'] as $listName) {
+    foreach (['provincies'] as $listName) {
         if (isset($$listName) && is_array($$listName)) {
             foreach ($$listName as $slug => $data) {
                 $og_pages['dating-' . $slug] = [

--- a/ZB/includes/header.php
+++ b/ZB/includes/header.php
@@ -8,6 +8,8 @@
   if (file_exists($base . '/includes/array_prov.php')) {
       include $base . '/includes/array_prov.php';
   }
+  // Expected province lists for this site
+  $provinceLists = ['provincies'];
   // Config is required for API lookups when rendering profile pages
   // Capture the returned configuration array for later use
   $config = include $base . '/includes/config.php';
@@ -64,7 +66,7 @@
     $og_image = $default_image;
     $og_url = $canonicalUrl;
     $og_pages = [];
-    foreach (['provincies', 'de', 'at', 'ch'] as $listName) {
+    foreach (['provincies'] as $listName) {
         if (isset($$listName) && is_array($$listName)) {
             foreach ($$listName as $slug => $data) {
                 $og_pages['dating-' . $slug] = [


### PR DESCRIPTION
## Summary
- document expected province arrays with a `$provinceLists` variable
- limit loops in DC/ONL/ZB to just the `provincies` list
- keep the full list in DN

## Testing
- `php -l DC/includes/header.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8f6605748324a7463a29906bfedc