### PR TITLE
Fix base prefixes for sitemap generation

### DIFF
--- a/18D/generate_sitemap.php
+++ b/18D/generate_sitemap.php
@@ -12,12 +12,8 @@ require __DIR__ . '/includes/array_tips.php';
 
 $baseUrl = getenv('ONL_BASE_URL') ?: $BASE_URL;
 
-$profilePrefix = 'date-';
-$slugPrefix = 'sexdate-';
-if (strpos($baseUrl, 'shemaledaten.net') !== false) {
-    $profilePrefix = 'shemale-';
-    $slugPrefix = 'shemale-';
-}
+$profilePrefix = $PROFILE_PREFIX;
+$slugPrefix = $SLUG_PREFIX;
 
 $urls = [];
 $static = ['', 'datingtips', 'partnerlinks', 'privacy', 'cookie-policy'];

--- a/18D/includes/config.php
+++ b/18D/includes/config.php
@@ -1,5 +1,7 @@
 <?php
 $BASE_URL = getenv('ONL_BASE_URL') ?: 'https://18date.net';
+$PROFILE_PREFIX = 'date-';
+$SLUG_PREFIX = 'sexdate-';
 // Configuration for API endpoints. When BASE_API_URL is defined it overrides the
 // country specific values so a single environment variable can be used just
 // like for the other sites.

--- a/S55/generate_sitemap.php
+++ b/S55/generate_sitemap.php
@@ -12,12 +12,8 @@ require __DIR__ . '/includes/array_tips.php';
 
 $baseUrl = getenv('ONL_BASE_URL') ?: $BASE_URL;
 
-$profilePrefix = 'date-';
-$slugPrefix = 'sexdate-';
-if (strpos($baseUrl, 'shemaledaten.net') !== false) {
-    $profilePrefix = 'shemale-';
-    $slugPrefix = 'shemale-';
-}
+$profilePrefix = $PROFILE_PREFIX;
+$slugPrefix = $SLUG_PREFIX;
 
 $urls = [];
 $static = ['', 'datingtips', 'partnerlinks', 'privacy', 'cookie-policy'];

--- a/S55/includes/config.php
+++ b/S55/includes/config.php
@@ -1,5 +1,7 @@
 <?php
 $BASE_URL = getenv('ONL_BASE_URL') ?: 'https://sex55.net';
+$PROFILE_PREFIX = 'date-';
+$SLUG_PREFIX = 'sexdate-';
 $commonApi      = getenv('BASE_API_URL');
 $API_BASE_DEFAULT = getenv('API_BASE_URL_DEFAULT')
     ?: ($commonApi ?: 'https://16hl07csd16.nl');

--- a/SD/generate_sitemap.php
+++ b/SD/generate_sitemap.php
@@ -12,12 +12,8 @@ require __DIR__ . '/includes/array_tips.php';
 
 $baseUrl = getenv('ONL_BASE_URL') ?: $BASE_URL;
 
-$profilePrefix = 'date-';
-$slugPrefix = 'sexdate-';
-if (strpos($baseUrl, 'shemaledaten.net') !== false) {
-    $profilePrefix = 'shemale-';
-    $slugPrefix = 'shemale-';
-}
+$profilePrefix = $PROFILE_PREFIX;
+$slugPrefix = $SLUG_PREFIX;
 
 $urls = [];
 $static = ['', 'datingtips', 'partnerlinks', 'privacy', 'cookie-policy'];

--- a/SD/includes/config.php
+++ b/SD/includes/config.php
@@ -1,5 +1,7 @@
 <?php
 $BASE_URL = getenv('ONL_BASE_URL') ?: 'https://shemaledaten.net';
+$PROFILE_PREFIX = 'shemale-';
+$SLUG_PREFIX = 'shemale-';
 $commonApi      = getenv('BASE_API_URL');
 $API_BASE_DEFAULT = getenv('API_BASE_URL_DEFAULT')
     ?: ($commonApi ?: 'https://16hl07csd16.nl');


### PR DESCRIPTION
## Summary
- define `PROFILE_PREFIX` and `SLUG_PREFIX` constants in configs
- use those constants when building profile links in the sitemap generator

## Testing
- `npm test` in `18D`
- `npm test` in `S55`
- `npm test` in `SD` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6878a8be278c832497b52d2eb24c1e67