### PR TITLE
Handle empty slugs when generating profile links

### DIFF
--- a/18D/generate_sitemap.php
+++ b/18D/generate_sitemap.php
@@ -54,6 +54,9 @@ foreach ($countryMap as $code => $info) {
                 continue;
             }
             $slugified = slugify($p['name']);
+            if ($slugified === '') {
+                continue;  // skip profiles without a usable slug
+            }
             $profileUrls[$p['id']] = $baseUrl . '/' . $profilePrefix . $slugified . '?country=' . $code . '&id=' . $p['id'];
         }
     }

--- a/DC/generate_sitemap.php
+++ b/DC/generate_sitemap.php
@@ -41,6 +41,9 @@ foreach ($countryMap as $code => $provArr) {
         foreach ($data['profiles'] as $prof) {
             if (empty($prof['id']) || empty($prof['name'])) continue;
             $slug = slugify($prof['name']);
+            if ($slug === '') {
+                continue; // skip profiles without a usable slug
+            }
             $profilePaths[$prof['id']] = $baseUrl . '/date-with-' . $slug . '?id=' . $prof['id'];
         }
     }

--- a/DC/includes/site.php
+++ b/DC/includes/site.php
@@ -30,11 +30,19 @@ function generate_canonical(string $baseUrl, string $apiEndpoint, string $slugPr
         $title = 'Dating ' . htmlspecialchars($_GET['item']);
     } elseif (isset($_GET['slug'])) {
         $slug = slugify($_GET['slug']);
-        $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
-        if (isset($_GET['id']) && is_numeric($_GET['id'])) {
-            $canonicalUrl .= '?id=' . $_GET['id'];
+        if ($slug !== '') {
+            $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+            if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+                $canonicalUrl .= '?id=' . $_GET['id'];
+            }
+            $title = $titlePrefix . ucwords(str_replace('-', ' ', $slug));
+        } else {
+            $canonicalUrl = $baseUrl . '/profile';
+            if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+                $canonicalUrl .= '?id=' . $_GET['id'];
+            }
+            $title = $titlePrefix . ($_GET['id'] ?? '');
         }
-        $title = $titlePrefix . ucwords(str_replace('-', ' ', $slug));
     } elseif (isset($_GET['id'])) {
         $id = preg_replace('/[^0-9]/', '', $_GET['id']);
         $apiResponse = @file_get_contents($apiEndpoint . $id);
@@ -43,7 +51,11 @@ function generate_canonical(string $baseUrl, string $apiEndpoint, string $slugPr
             if (isset($data['profile']['name'])) {
                 $profileName = $data['profile']['name'];
                 $slug = slugify($profileName);
-                $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+                if ($slug !== '') {
+                    $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+                } else {
+                    $canonicalUrl = $baseUrl . '/profile?id=' . htmlspecialchars($_GET['id']);
+                }
                 $title = $titlePrefix . htmlspecialchars($profileName);
             } else {
                 $canonicalUrl = $baseUrl . '/profile?id=' . htmlspecialchars($_GET['id']);

--- a/DN/generate_sitemap.php
+++ b/DN/generate_sitemap.php
@@ -50,6 +50,9 @@ foreach ($countryMap as $code => $provArr) {
         foreach ($data['profiles'] as $prof) {
             if (empty($prof['id']) || empty($prof['name'])) continue;
             $slug = slugify($prof['name']);
+            if ($slug === '') {
+                continue; // skip profiles without a usable slug
+            }
             $profilePaths[$prof['id']] = $baseUrl . '/date-mit-' . $slug . '?id=' . $prof['id'];
         }
     }

--- a/DN/includes/site.php
+++ b/DN/includes/site.php
@@ -30,11 +30,19 @@ function generate_canonical(string $baseUrl, string $apiEndpoint, string $slugPr
         $title = 'Dating ' . htmlspecialchars($_GET['item']);
     } elseif (isset($_GET['slug'])) {
         $slug = slugify($_GET['slug']);
-        $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
-        if (isset($_GET['id']) && is_numeric($_GET['id'])) {
-            $canonicalUrl .= '?id=' . $_GET['id'];
+        if ($slug !== '') {
+            $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+            if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+                $canonicalUrl .= '?id=' . $_GET['id'];
+            }
+            $title = $titlePrefix . ucwords(str_replace('-', ' ', $slug));
+        } else {
+            $canonicalUrl = $baseUrl . '/profile';
+            if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+                $canonicalUrl .= '?id=' . $_GET['id'];
+            }
+            $title = $titlePrefix . ($_GET['id'] ?? '');
         }
-        $title = $titlePrefix . ucwords(str_replace('-', ' ', $slug));
     } elseif (isset($_GET['id'])) {
         $id = preg_replace('/[^0-9]/', '', $_GET['id']);
         $apiResponse = @file_get_contents($apiEndpoint . $id);
@@ -43,7 +51,11 @@ function generate_canonical(string $baseUrl, string $apiEndpoint, string $slugPr
             if (isset($data['profile']['name'])) {
                 $profileName = $data['profile']['name'];
                 $slug = slugify($profileName);
-                $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+                if ($slug !== '') {
+                    $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+                } else {
+                    $canonicalUrl = $baseUrl . '/profile?id=' . htmlspecialchars($_GET['id']);
+                }
                 $title = $titlePrefix . htmlspecialchars($profileName);
             } else {
                 $canonicalUrl = $baseUrl . '/profile?id=' . htmlspecialchars($_GET['id']);

--- a/ONL/generate_sitemap.php
+++ b/ONL/generate_sitemap.php
@@ -41,6 +41,9 @@ foreach ($countryMap as $code => $provArr) {
         foreach ($data['profiles'] as $prof) {
             if (empty($prof['id']) || empty($prof['name'])) continue;
             $slug = slugify($prof['name']);
+            if ($slug === '') {
+                continue; // skip profiles without a usable slug
+            }
             $profilePaths[$prof['id']] = $baseUrl . '/daten-met-' . $slug . '?id=' . $prof['id'];
         }
     }

--- a/ONL/includes/site.php
+++ b/ONL/includes/site.php
@@ -30,11 +30,19 @@ function generate_canonical(string $baseUrl, string $apiEndpoint, string $slugPr
         $title = 'Dating ' . htmlspecialchars($_GET['item']);
     } elseif (isset($_GET['slug'])) {
         $slug = slugify($_GET['slug']);
-        $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
-        if (isset($_GET['id']) && is_numeric($_GET['id'])) {
-            $canonicalUrl .= '?id=' . $_GET['id'];
+        if ($slug !== '') {
+            $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+            if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+                $canonicalUrl .= '?id=' . $_GET['id'];
+            }
+            $title = $titlePrefix . ucwords(str_replace('-', ' ', $slug));
+        } else {
+            $canonicalUrl = $baseUrl . '/profile';
+            if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+                $canonicalUrl .= '?id=' . $_GET['id'];
+            }
+            $title = $titlePrefix . ($_GET['id'] ?? '');
         }
-        $title = $titlePrefix . ucwords(str_replace('-', ' ', $slug));
     } elseif (isset($_GET['id'])) {
         $id = preg_replace('/[^0-9]/', '', $_GET['id']);
         $apiResponse = @file_get_contents($apiEndpoint . $id);
@@ -43,7 +51,11 @@ function generate_canonical(string $baseUrl, string $apiEndpoint, string $slugPr
             if (isset($data['profile']['name'])) {
                 $profileName = $data['profile']['name'];
                 $slug = slugify($profileName);
-                $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+                if ($slug !== '') {
+                    $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+                } else {
+                    $canonicalUrl = $baseUrl . '/profile?id=' . htmlspecialchars($_GET['id']);
+                }
                 $title = $titlePrefix . htmlspecialchars($profileName);
             } else {
                 $canonicalUrl = $baseUrl . '/profile?id=' . htmlspecialchars($_GET['id']);

--- a/S55/generate_sitemap.php
+++ b/S55/generate_sitemap.php
@@ -54,6 +54,9 @@ foreach ($countryMap as $code => $info) {
                 continue;
             }
             $slugified = slugify($p['name']);
+            if ($slugified === '') {
+                continue;  // skip profiles without a usable slug
+            }
             $profileUrls[$p['id']] = $baseUrl . '/' . $profilePrefix . $slugified . '?country=' . $code . '&id=' . $p['id'];
         }
     }

--- a/SD/generate_sitemap.php
+++ b/SD/generate_sitemap.php
@@ -54,6 +54,9 @@ foreach ($countryMap as $code => $info) {
                 continue;
             }
             $slugified = slugify($p['name']);
+            if ($slugified === '') {
+                continue;  // skip profiles without a usable slug
+            }
             $profileUrls[$p['id']] = $baseUrl . '/' . $profilePrefix . $slugified . '?country=' . $code . '&id=' . $p['id'];
         }
     }

--- a/ZB/generate_sitemap.php
+++ b/ZB/generate_sitemap.php
@@ -41,6 +41,9 @@ foreach ($countryMap as $code => $provArr) {
         foreach ($data['profiles'] as $prof) {
             if (empty($prof['id']) || empty($prof['name'])) continue;
             $slug = slugify($prof['name']);
+            if ($slug === '') {
+                continue; // skip profiles without a usable slug
+            }
             $profilePaths[$prof['id']] = $baseUrl . '/daten-met-' . $slug . '?id=' . $prof['id'];
         }
     }

--- a/ZB/includes/site.php
+++ b/ZB/includes/site.php
@@ -30,11 +30,19 @@ function generate_canonical(string $baseUrl, string $apiEndpoint, string $slugPr
         $title = 'Dating ' . htmlspecialchars($_GET['item']);
     } elseif (isset($_GET['slug'])) {
         $slug = slugify($_GET['slug']);
-        $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
-        if (isset($_GET['id']) && is_numeric($_GET['id'])) {
-            $canonicalUrl .= '?id=' . $_GET['id'];
+        if ($slug !== '') {
+            $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+            if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+                $canonicalUrl .= '?id=' . $_GET['id'];
+            }
+            $title = $titlePrefix . ucwords(str_replace('-', ' ', $slug));
+        } else {
+            $canonicalUrl = $baseUrl . '/profile';
+            if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+                $canonicalUrl .= '?id=' . $_GET['id'];
+            }
+            $title = $titlePrefix . ($_GET['id'] ?? '');
         }
-        $title = $titlePrefix . ucwords(str_replace('-', ' ', $slug));
     } elseif (isset($_GET['id'])) {
         $id = preg_replace('/[^0-9]/', '', $_GET['id']);
         $apiResponse = @file_get_contents($apiEndpoint . $id);
@@ -43,7 +51,11 @@ function generate_canonical(string $baseUrl, string $apiEndpoint, string $slugPr
             if (isset($data['profile']['name'])) {
                 $profileName = $data['profile']['name'];
                 $slug = slugify($profileName);
-                $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+                if ($slug !== '') {
+                    $canonicalUrl = $baseUrl . '/' . $slugPrefix . '-' . $slug;
+                } else {
+                    $canonicalUrl = $baseUrl . '/profile?id=' . htmlspecialchars($_GET['id']);
+                }
                 $title = $titlePrefix . htmlspecialchars($profileName);
             } else {
                 $canonicalUrl = $baseUrl . '/profile?id=' . htmlspecialchars($_GET['id']);


### PR DESCRIPTION
## Summary
- skip profiles that slugify to an empty string when building sitemap URLs
- guard against empty slugs in canonical URL generation
- regenerate sitemaps to verify scripts still run

## Testing
- `php 18D/generate_sitemap.php`
- `for dir in S55 SD ONL DC DN ZB; do php $dir/generate_sitemap.php; done`


------
https://chatgpt.com/codex/tasks/task_e_6878cf884bcc832496a98c5d4bf77f50