### PR TITLE
Serve general dating tips on /datingtips path

### DIFF
--- a/DN/datingtips.php
+++ b/DN/datingtips.php
@@ -8,30 +8,17 @@ include $base . '/includes/array_tips.php';
 require_once $base . '/includes/utils.php';
 
 $param = $_GET['tip'] ?? $_GET['item'] ?? null;
-$tipSlug = null;
 if ($param !== null) {
     $candidate = strip_bad_chars($param);
     if (isset($datingtips[$candidate])) {
         $tipSlug = $candidate;
+    } else {
+        http_response_code(404);
+        include $base . '/404.php';
+        return;
     }
-}
-
-if ($tipSlug === null) {
-    $metaDescription = 'Entdecke hilfreiche Datingtipps bei Dating Nebenan.';
-    include $base . '/includes/header.php';
-    ?>
-    <div class="container">
-        <div class='jumbotron my-4 text-center'>
-            <h1>Datingtipps</h1>
-            <p>Wähle einen unserer Tipps:</p>
-            <?php foreach ($datingtips as $slug => $tip) { ?>
-                <p><a class="btn btn-primary btn-tips" href="datingtips-<?php echo $slug; ?>"><?php echo htmlspecialchars($tip['name']); ?></a></p>
-            <?php } ?>
-        </div>
-    </div>
-    <?php include $base . '/includes/footer.php'; ?>
-    <?php
-    return;
+} else {
+    $tipSlug = 'datingtips';
 }
 
 $tips = $datingtips[$tipSlug];

--- a/DN/router.php
+++ b/DN/router.php
@@ -54,13 +54,19 @@ if (preg_match('#^/datingtips-([^/]+)$#', $path, $m)) {
     return;
 }
 
+// /datingtips => datingtips.php?tip=datingtips
+if ($path === '/datingtips') {
+    $_GET['tip'] = 'datingtips';
+    include __DIR__ . '/datingtips.php';
+    return;
+}
+
 $routes = [
     '/'              => 'index.php',
     '/index'         => 'index.php',
     '/partnerlinks'  => 'partnerlinks.php',
     '/privacy'       => 'privacy.php',
     '/cookie-policy' => 'cookie-policy.php',
-    '/datingtips'    => 'datingtips.php',
     '/land'          => 'land.php',
 ];
 


### PR DESCRIPTION
## Summary
- Direct `/datingtips` requests to the existing general tips article by routing them with `tip=datingtips`.
- Simplify `datingtips.php` to show the general tips by default and return a 404 on unknown tips, removing the listing page.

## Testing
- `php -l DN/router.php`
- `php -l DN/datingtips.php`


------
https://chatgpt.com/codex/tasks/task_e_68a45e15b358832491ac5125828ebe49