### PR TITLE
Fix datingtipps navigation and redirects

### DIFF
--- a/DN/.htaccess
+++ b/DN/.htaccess
@@ -18,6 +18,10 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^dating-([^/]+)/?$ provincie.php?item=$1 [L,QSA]
 
+# Redirect old datingtips URLs
+RewriteRule ^datingtips-([^/]+)/?$ /datingtipps-$1 [R=301,L]
+RewriteRule ^datingtips/?$ /datingtipps [R=301,L]
+
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^datingtipps-([^/]+)/?$ datingtips.php?tip=$1 [L,QSA]

--- a/DN/includes/nav.php
+++ b/DN/includes/nav.php
@@ -7,7 +7,7 @@
 <?php } ?>
     <!-- Datingtips links -->
     <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle drpdwn" href="#" id="navbarDropdownTips" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Datingtipps</a>
+        <a class="nav-link dropdown-toggle drpdwn" href="datingtipps" id="navbarDropdownTips" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Datingtipps</a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownTips">
             <?php foreach ($datingtips as $slug => $tip) {
                     if (empty($tip['name'])) {


### PR DESCRIPTION
## Summary
- Redirect legacy `/datingtips` URLs to `/datingtipps` to avoid 404s.
- Make the "Datingtipps" navigation link point to the main tips page.

## Testing
- `php -l DN/includes/nav.php`
- `php -l DN/datingtips.php`


------
https://chatgpt.com/codex/tasks/task_e_68a46b25b8588324b66daffb3bc0a86f