### PR TITLE
Add server-side profile index page

### DIFF
--- a/DN/includes/footer.php
+++ b/DN/includes/footer.php
@@ -1,6 +1,7 @@
 <!-- Footer -->
 <footer>
     <ul class="footer-links">
+        <li><a href="/profielen" class="m-0">Profielen</a> - </li>
         <li><a href="https://18date.net/" target="_blank" class="m-0">18Date</a> - </li>
         <li><a href="https://sex55.net/" target="_blank" class="m-0">Sex55</a> - </li>
         <li><a href="https://shemaledaten.net/" target="_blank" class="m-0">Shemale Daten</a> - </li>

--- a/DN/includes/header.php
+++ b/DN/includes/header.php
@@ -36,6 +36,9 @@
 ?>
 <meta name="description" content="<?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?>">
 <meta name="author" content="Dating Nebenan">
+<?php if (isset($metaRobots)): ?>
+<meta name="robots" content="<?php echo htmlspecialchars($metaRobots, ENT_QUOTES, 'UTF-8'); ?>">
+<?php endif; ?>
 <link rel="apple-touch-icon" sizes="180x180" href="img/fav/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="img/fav/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="img/fav/favicon-16x16.png">

--- a/DN/profielen.php
+++ b/DN/profielen.php
@@ -1,0 +1,89 @@
+<?php
+$base = __DIR__;
+require_once $base . '/includes/utils.php';
+require_once $base . '/includes/site.php';
+$config = include $base . '/includes/config.php';
+
+$perPage = 120;
+$page = isset($_GET['page']) && ctype_digit($_GET['page']) && $_GET['page'] > 0 ? (int)$_GET['page'] : 1;
+
+$cacheFile = sys_get_temp_dir() . '/dn_profiles_cache.json';
+$cacheTtl = 300; // 5 minutes
+$profiles = [];
+$apiError = false;
+
+if (file_exists($cacheFile) && (time() - filemtime($cacheFile) < $cacheTtl)) {
+    $data = json_decode(@file_get_contents($cacheFile), true);
+    if (isset($data['profiles']) && is_array($data['profiles'])) {
+        $profiles = $data['profiles'];
+    }
+}
+
+if (!$profiles) {
+    $response = @file_get_contents($config['BANNER_ENDPOINT']);
+    if ($response !== false) {
+        $data = json_decode($response, true);
+        if (isset($data['profiles']) && is_array($data['profiles'])) {
+            $profiles = $data['profiles'];
+            @file_put_contents($cacheFile, $response);
+        } else {
+            $apiError = true;
+        }
+    } else {
+        $apiError = true;
+    }
+}
+
+$totalProfiles = count($profiles);
+$totalPages = $totalProfiles > 0 ? (int)ceil($totalProfiles / $perPage) : 1;
+$startIndex = ($page - 1) * $perPage;
+$profilesSlice = array_slice($profiles, $startIndex, $perPage);
+
+$baseUrl = get_base_url('https://datingnebenan.de');
+$canonical = $baseUrl . '/profielen' . ($page > 1 ? '?page=' . $page : '');
+$pageTitle = 'Profielen — Dating Nebenan';
+$metaRobots = 'index,follow';
+
+if ($apiError) {
+    http_response_code(500);
+}
+
+include $base . '/includes/header.php';
+?>
+<div class="container">
+    <h1>Profielen</h1>
+<?php if ($apiError): ?>
+    <p>Er ging iets mis bij het ophalen van de profielen.</p>
+<?php else: ?>
+    <ul>
+    <?php foreach ($profilesSlice as $p):
+        $name = htmlspecialchars($p['name'] ?? '', ENT_QUOTES, 'UTF-8');
+        $city = htmlspecialchars($p['city'] ?? '', ENT_QUOTES, 'UTF-8');
+        $id = (int)($p['id'] ?? 0);
+        $slug = slugify($name);
+        $url = '/date-mit-' . $slug . '?id=' . $id;
+    ?>
+        <li><a href="<?= $url ?>"><?= $name ?><?php if ($city) echo ' — ' . $city; ?></a></li>
+    <?php endforeach; ?>
+    </ul>
+    <?php if ($totalPages > 1): ?>
+    <nav aria-label="Paginierung">
+        <ul class="pagination">
+            <?php if ($page > 1):
+                $prev = $page - 1;
+                $prevUrl = '/profielen' . ($prev > 1 ? '?page=' . $prev : '');
+            ?>
+            <li class="page-item"><a class="page-link" href="<?= $prevUrl ?>">Vorige</a></li>
+            <?php endif; ?>
+            <?php if ($page < $totalPages):
+                $next = $page + 1;
+                $nextUrl = '/profielen?page=' . $next;
+            ?>
+            <li class="page-item"><a class="page-link" href="<?= $nextUrl ?>">Volgende</a></li>
+            <?php endif; ?>
+        </ul>
+    </nav>
+    <?php endif; ?>
+<?php endif; ?>
+</div>
+<?php include $base . '/includes/footer.php'; ?>

--- a/DN/router.php
+++ b/DN/router.php
@@ -68,6 +68,7 @@ $routes = [
     '/privacy'       => 'privacy.php',
     '/cookie-policy' => 'cookie-policy.php',
     '/land'          => 'land.php',
+    '/profielen'     => 'profielen.php',
 ];
 
 if (isset($routes[$path])) {


### PR DESCRIPTION
## Summary
- add `/profielen` route that server-side renders a list of profile links
- expose internal link to the profile index in the global footer
- allow pages to define `meta` robots via header helper

## Testing
- `php -l DN/profielen.php && php -l DN/includes/footer.php && php -l DN/router.php && php -l DN/includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68a47b52c990832488ba0fbbf7882d87