### PR TITLE
Use paginated profile API with per-page caching

### DIFF
--- a/DN/profielen.php
+++ b/DN/profielen.php
@@ -25,8 +25,15 @@ if (file_exists($cacheFile) && (time() - filemtime($cacheFile) < $cacheTtl)) {
 
 if (!$profiles) {
     $apiUrl = $config['BASE_API_URL'] . '/profiles?page=' . $page . '&per_page=' . $perPage;
-    $response = @file_get_contents($apiUrl);
-    if ($response !== false) {
+    $ch = curl_init($apiUrl);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT => 5,
+        CURLOPT_CONNECTTIMEOUT => 5,
+    ]);
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    if ($response !== false && $httpCode === 200) {
         $data = json_decode($response, true);
         if (isset($data['profiles']) && is_array($data['profiles'])) {
             $profiles = $data['profiles'];
@@ -39,6 +46,7 @@ if (!$profiles) {
     } else {
         $apiError = true;
     }
+    curl_close($ch);
 }
 
 $totalProfiles = $totalProfiles ?: count($profiles);
@@ -90,9 +98,8 @@ include $base . '/includes/header.php';
                 <?php endif; ?>
             </ul>
         </nav>
+        <?php endif; ?>
+        <?php endif; ?>
     </div>
-<?php endif; ?>
-<?php endif; ?>
-</div>
 </div>
 <?php include $base . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- cache profile pages for 5 minutes using page-specific files
- request profiles via paginated API with cURL and store totals for navigation
- limit profile list to 120 entries with previous/next page links

## Testing
- `php -l DN/profielen.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4842e54808324b53c882579c1e28a