### PR TITLE
Use paginated profile API with per-page caching

### DIFF
--- a/DN/profielen.php
+++ b/DN/profielen.php
@@ -25,7 +25,12 @@ if (file_exists($cacheFile) && (time() - filemtime($cacheFile) < $cacheTtl)) {
 
 if (!$profiles) {
     $apiUrl = $config['BASE_API_URL'] . '/profiles?page=' . $page . '&per_page=' . $perPage;
-    $response = @file_get_contents($apiUrl);
+    $context = stream_context_create([
+        'http' => [
+            'timeout' => 5,
+        ],
+    ]);
+    $response = @file_get_contents($apiUrl, false, $context);
     if ($response !== false) {
         $data = json_decode($response, true);
         if (isset($data['profiles']) && is_array($data['profiles'])) {
@@ -57,42 +62,39 @@ if ($apiError) {
 include $base . '/includes/header.php';
 ?>
 <div class="container">
-    <div class="jumbotron jumbotron-sm">
-        <h1 class="text-center">Profielen</h1>
-        <?php if ($apiError): ?>
-            <p>Er ging iets mis bij het ophalen van de profielen.</p>
-        <?php else: ?>
-        <ul>
-        <?php foreach ($profilesSlice as $p):
-            $name = htmlspecialchars($p['name'] ?? '', ENT_QUOTES, 'UTF-8');
-            $city = htmlspecialchars($p['city'] ?? '', ENT_QUOTES, 'UTF-8');
-            $id = (int)($p['id'] ?? 0);
-            $slug = slugify($name);
-            $url = '/date-mit-' . $slug . '?id=' . $id;
-        ?>
-            <li><a href="<?= $url ?>"><?= $name ?><?php if ($city) echo ' — ' . $city; ?></a></li>
-        <?php endforeach; ?>
+    <h1>Profielen</h1>
+<?php if ($apiError): ?>
+    <p>Er ging iets mis bij het ophalen van de profielen.</p>
+<?php else: ?>
+    <ul>
+    <?php foreach ($profilesSlice as $p):
+        $name = htmlspecialchars($p['name'] ?? '', ENT_QUOTES, 'UTF-8');
+        $city = htmlspecialchars($p['city'] ?? '', ENT_QUOTES, 'UTF-8');
+        $id = (int)($p['id'] ?? 0);
+        $slug = slugify($name);
+        $url = '/date-mit-' . $slug . '?id=' . $id;
+    ?>
+        <li><a href="<?= $url ?>"><?= $name ?><?php if ($city) echo ' — ' . $city; ?></a></li>
+    <?php endforeach; ?>
+    </ul>
+    <?php if ($totalPages > 1): ?>
+    <nav aria-label="Paginierung">
+        <ul class="pagination">
+            <?php if ($page > 1):
+                $prev = $page - 1;
+                $prevUrl = '/profielen' . ($prev > 1 ? '?page=' . $prev : '');
+            ?>
+            <li class="page-item"><a class="page-link" href="<?= $prevUrl ?>">Vorige</a></li>
+            <?php endif; ?>
+            <?php if ($page < $totalPages):
+                $next = $page + 1;
+                $nextUrl = '/profielen?page=' . $next;
+            ?>
+            <li class="page-item"><a class="page-link" href="<?= $nextUrl ?>">Volgende</a></li>
+            <?php endif; ?>
         </ul>
-        <?php if ($totalPages > 1): ?>
-        <nav aria-label="Paginierung">
-            <ul class="pagination">
-                <?php if ($page > 1):
-                    $prev = $page - 1;
-                    $prevUrl = '/profielen' . ($prev > 1 ? '?page=' . $prev : '');
-                ?>
-                <li class="page-item"><a class="page-link" href="<?= $prevUrl ?>">Vorige</a></li>
-                <?php endif; ?>
-                <?php if ($page < $totalPages):
-                    $next = $page + 1;
-                    $nextUrl = '/profielen?page=' . $next;
-                ?>
-                <li class="page-item"><a class="page-link" href="<?= $nextUrl ?>">Volgende</a></li>
-                <?php endif; ?>
-            </ul>
-        </nav>
-    </div>
+    </nav>
+    <?php endif; ?>
 <?php endif; ?>
-<?php endif; ?>
-</div>
 </div>
 <?php include $base . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- cache profile pages for 5 minutes using page-specific files
- fetch profiles via paginated API using `file_get_contents`
- limit listing to 120 profiles with previous/next page links

## Testing
- `php -l DN/profielen.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4842e54808324b53c882579c1e28a