### PR TITLE
Read profiles from CSV file

### DIFF
--- a/DN/data/profielen.csv
+++ b/DN/data/profielen.csv
@@ -1,0 +1,3 @@
+id,name,city
+1,Anna,Berlin
+2,Berta,München


### PR DESCRIPTION
## Summary
- Replace API-based profile listing with CSV reader and pagination
- Add sample `data/profielen.csv` for profile links

## Testing
- `php -l DN/profielen.php`

------
https://chatgpt.com/codex/tasks/task_e_68a561a2147083249fc40befbe31837e