### PR TITLE
Display profiles from CSV

### DIFF
--- a/DN/profielen.php
+++ b/DN/profielen.php
@@ -5,7 +5,7 @@ require_once $base . '/includes/site.php';
 
 // ==== CONFIG ====
 $csvPath   = $base . '/data/profielen.csv';
-$delimiter = ',';
+$delimiter = ';';
 $hasHeader = true;
 $idField   = 'id';
 $nameField = 'name';
@@ -24,7 +24,16 @@ function csvIterator(string $path, string $delimiter = ',', bool $hasHeader = tr
     foreach ($f as $row) {
         if ($row === [null] || $row === false) { continue; }
         if ($headers === null) {
-            if ($hasHeader) { $headers = $row; continue; }
+            if ($hasHeader) {
+                // remove possible UTF-8 BOM and whitespace from header names
+                $headers = array_map(function ($h) {
+                    $h = (string) $h;
+                    // strip BOM if present
+                    $h = preg_replace('/^\xEF\xBB\xBF/', '', $h);
+                    return trim($h);
+                }, $row);
+                continue;
+            }
             $headers = array_map(fn($i) => "col_$i", array_keys($row));
         }
         $assoc = [];
@@ -38,12 +47,17 @@ function csvIterator(string $path, string $delimiter = ',', bool $hasHeader = tr
 // ==== LOAD PROFILES ====
 $profiles = [];
 try {
+    $count = 0;
     foreach (csvIterator($csvPath, $delimiter, $hasHeader) as $rec) {
         $id = trim((string)($rec[$idField] ?? ''));
         if ($id === '') {
             continue;
         }
         $profiles[] = $rec;
+        $count++;
+        if ($count >= 500) {
+            break; // max 500 profielen per pagina
+        }
     }
 } catch (Throwable $e) {
     http_response_code(500);
@@ -64,26 +78,26 @@ include $base . '/includes/header.php';
     <?php if (empty($profiles)): ?>
         <p>Geen profielen gevonden.</p>
     <?php else: ?>
-    <ul class="list-unstyled">
-        <?php foreach ($profiles as $r):
-            $id   = trim((string)($r[$idField] ?? ''));
-            if ($id === '') continue;
-            $name = $r[$nameField] ?? ('Profil ' . $id);
-            $city = $r[$cityField] ?? '';
-            $link = $r[$linkField] ?? '';
-        ?>
-        <li class="mb-1">
-            <?php if ($link !== ''): ?>
-                <a href="<?=h($link)?>" target="_blank" rel="noopener"><?=h($name)?></a>
-            <?php else: ?>
-                <span><?=h($name)?></span>
-            <?php endif; ?>
-            <?php if ($city !== ''): ?>
-                <span class="text-muted"> — <?=h($city)?></span>
-            <?php endif; ?>
-        </li>
+    <?php $chunks = array_chunk($profiles, 250); ?>
+    <div class="row">
+        <?php foreach ($chunks as $chunk): ?>
+        <div class="col-md-6">
+            <ul class="list-unstyled">
+                <?php foreach ($chunk as $r):
+                    $id   = trim((string)($r[$idField] ?? ''));
+                    if ($id === '') continue;
+                    $name = $r[$nameField] ?? ('Profil ' . $id);
+                    $city = $r[$cityField] ?? '';
+                    $link = $r[$linkField] ?? '';
+                ?>
+                <li class="mb-1">
+                    <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>" target="_blank" rel="noopener"><?=h($link)?></a>
+                </li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
         <?php endforeach; ?>
-    </ul>
+    </div>
     <?php endif; ?>
 </div>
 <?php include $base . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Parse `DN/data/profielen.csv` while trimming UTF-8 BOM from headers
- Display up to 500 profiles in two columns with name, city, and link

## Testing
- `php -l DN/profielen.php`
- `php DN/profielen.php >/tmp/profielen_output.html && grep -n 'suesseslenchen' /tmp/profielen_output.html`
- `grep -c 'col-md-6' /tmp/profielen_output.html`


------
https://chatgpt.com/codex/tasks/task_e_68a57082693c83248ae02cf18d09bef1