### PR TITLE
Add pagination to profielen page

### DIFF
--- a/DN/profielen.php
+++ b/DN/profielen.php
@@ -47,26 +47,28 @@ function csvIterator(string $path, string $delimiter = ',', bool $hasHeader = tr
 // ==== LOAD PROFILES ====
 $profiles = [];
 try {
-    $count = 0;
     foreach (csvIterator($csvPath, $delimiter, $hasHeader) as $rec) {
         $id = trim((string)($rec[$idField] ?? ''));
         if ($id === '') {
             continue;
         }
         $profiles[] = $rec;
-        $count++;
-        if ($count >= 500) {
-            break; // max 500 profielen per pagina
-        }
     }
 } catch (Throwable $e) {
     http_response_code(500);
     echo '<p>Fout bij lezen CSV: ' . h($e->getMessage()) . '</p>';
     exit;
 }
+// ==== PAGINATION ====
+$perPage = 500;
+$page    = max(1, (int)($_GET['page'] ?? 1));
+$total   = count($profiles);
+$pages   = (int) ceil($total / $perPage);
+$offset  = ($page - 1) * $perPage;
+$profiles = array_slice($profiles, $offset, $perPage);
 
 $baseUrl  = get_base_url('https://datingnebenan.de');
-$canonical = $baseUrl . '/profielen';
+$canonical = $baseUrl . '/profielen' . ($page > 1 ? '?page=' . $page : '');
 $pageTitle = 'Profielen — Dating Nebenan';
 $metaRobots = 'index,follow';
 
@@ -91,13 +93,24 @@ include $base . '/includes/header.php';
                     $link = $r[$linkField] ?? '';
                 ?>
                 <li class="mb-1">
-                    <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>"><?=h($link)?></a>
+                    <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>">Bekijk profiel</a>
                 </li>
                 <?php endforeach; ?>
             </ul>
         </div>
         <?php endforeach; ?>
     </div>
+    <?php if ($pages > 1): ?>
+    <nav aria-label="Profielen paginering">
+        <ul class="pagination">
+            <?php for ($p = 1; $p <= $pages; $p++): ?>
+            <li class="page-item<?= $p === $page ? ' active' : '' ?>">
+                <a class="page-link" href="?page=<?=$p?>"><?=$p?></a>
+            </li>
+            <?php endfor; ?>
+        </ul>
+    </nav>
+    <?php endif; ?>
     <?php endif; ?>
 </div>
 <?php include $base . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Add server-side pagination to load all profiles and update canonical URLs accordingly
- Replace raw profile URLs with "Bekijk profiel" link text
- Mirror these updates in .well-known variant of profielen page

## Testing
- `php -l DN/profielen.php DN/.well-known/profielen.php`


------
https://chatgpt.com/codex/tasks/task_e_68a57482ae808324bbec96a182126a7a