### PR TITLE
Add profile listings for all sites with localized pagination

### DIFF
--- a/18D/includes/footer.php
+++ b/18D/includes/footer.php
@@ -1,7 +1,8 @@
 <!-- Footer -->
 <footer class="bg-dark">
-	<ul class="footer-links">
-		<li><a href="https://sex55.net/" target="_blank" class="m-0">Sex55</a> - </li>
+        <ul class="footer-links">
+                <li><a href="/profielen.php" class="m-0">Profielen</a> - </li>
+                <li><a href="https://sex55.net/" target="_blank" class="m-0">Sex55</a> - </li>
 		<li><a href="https://shemaledaten.net/" target="_blank" class="m-0">Shemale Daten</a> - </li>
 		<li><a href="https://oproepjesnederland.nl/" target="_blank" class="m-0">Oproepjes Nederland</a> - </li>
 		<li><a href="https://zoekertjesbelgie.be/" target="_blank" class="m-0">Zoekertjes België</a> - </li>

--- a/18D/profielen.php
+++ b/18D/profielen.php
@@ -1,0 +1,143 @@
+<?php
+$base = __DIR__;
+require_once $base . '/includes/utils.php';
+require_once $base . '/includes/site.php';
+
+// ==== CONFIG ====
+$csvPath   = $base . '/data/profielen.csv';
+$delimiter = ';';
+$hasHeader = true;
+$idField   = 'id';
+$nameField = 'name';
+$cityField = 'city';
+$linkField = 'link';
+
+// ==== HELPERS ====
+function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); }
+function csvIterator(string $path, string $delimiter = ',', bool $hasHeader = true): Generator {
+    if (!is_readable($path)) { throw new RuntimeException("CSV niet leesbaar: $path"); }
+    $f = new SplFileObject($path, 'r');
+    $f->setFlags(SplFileObject::READ_CSV | SplFileObject::SKIP_EMPTY | SplFileObject::DROP_NEW_LINE);
+    $f->setCsvControl($delimiter);
+
+    $headers = null;
+    foreach ($f as $row) {
+        if ($row === [null] || $row === false) { continue; }
+        if ($headers === null) {
+            if ($hasHeader) {
+                $headers = array_map(function ($h) {
+                    $h = (string) $h;
+                    $h = preg_replace('/^\xEF\xBB\xBF/', '', $h);
+                    return trim($h);
+                }, $row);
+                continue;
+            }
+            $headers = array_map(fn($i) => "col_$i", array_keys($row));
+        }
+        $assoc = [];
+        foreach ($headers as $i => $key) {
+            $assoc[$key] = $row[$i] ?? '';
+        }
+        yield $assoc;
+    }
+}
+
+// ==== LOAD PROFILES ====
+$profiles = [];
+try {
+    foreach (csvIterator($csvPath, $delimiter, $hasHeader) as $rec) {
+        $id = trim((string)($rec[$idField] ?? ''));
+        if ($id === '') {
+            continue;
+        }
+        $profiles[] = $rec;
+    }
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo '<p>Fout bij lezen CSV: ' . h($e->getMessage()) . '</p>';
+    exit;
+}
+
+// ==== PAGINATION ====
+$perPage = 500;
+$page    = max(1, (int)($_GET['page'] ?? 1));
+$total   = count($profiles);
+$pages   = (int) ceil($total / $perPage);
+$offset  = ($page - 1) * $perPage;
+$profiles = array_slice($profiles, $offset, $perPage);
+
+$baseUrl  = $BASE_URL;
+$canonical = $baseUrl . '/profielen' . ($page > 1 ? '?page=' . $page : '');
+$pageTitle = 'Profielen — 18Date.net';
+$metaRobots = 'index,follow';
+
+$t = [
+    'heading' => 'Profielen',
+    'no_profiles' => 'Geen profielen gevonden.',
+    'view_profile' => 'Bekijk profiel',
+    'first' => 'Eerste',
+    'prev' => 'Vorige',
+    'page_of' => 'Pagina %d van %d',
+    'next' => 'Volgende',
+    'last' => 'Laatste',
+    'pagination_label' => 'Profielen paginering',
+];
+
+include $base . '/includes/header.php';
+?>
+<div class="container">
+    <div class="jumbotron my-4">
+        <h1><?= $t['heading'] ?></h1>
+
+        <?php if (empty($profiles)): ?>
+            <p><?= $t['no_profiles'] ?></p>
+        <?php else: ?>
+        <?php $chunks = array_chunk($profiles, 250); ?>
+        <div class="row">
+            <?php foreach ($chunks as $chunk): ?>
+            <div class="col-md-6">
+                <ul class="list-unstyled">
+                    <?php foreach ($chunk as $r):
+                        $id   = trim((string)($r[$idField] ?? ''));
+                        if ($id === '') continue;
+                        $name = $r[$nameField] ?? ('Profiel ' . $id);
+                        $city = $r[$cityField] ?? '';
+                        $link = $r[$linkField] ?? '';
+                    ?>
+                    <li class="mb-1">
+                        <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>"><?= $t['view_profile'] ?></a>
+                    </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <?php if ($pages > 1): ?>
+    <nav aria-label="<?= $t['pagination_label'] ?>">
+        <?php
+        $prevPage = max(1, $page - 1);
+        $nextPage = min($pages, $page + 1);
+        ?>
+        <ul class="pagination">
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=1"><?= $t['first'] ?></a>
+            </li>
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$prevPage?>"><?= $t['prev'] ?></a>
+            </li>
+            <li class="page-item disabled">
+                <span class="page-link"><?php printf($t['page_of'], $page, $pages); ?></span>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$nextPage?>"><?= $t['next'] ?></a>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$pages?>"><?= $t['last'] ?></a>
+            </li>
+        </ul>
+    </nav>
+    <?php endif; ?>
+    <?php endif; ?>
+</div>
+<?php include $base . '/includes/footer.php'; ?>

--- a/DC/includes/footer.php
+++ b/DC/includes/footer.php
@@ -1,6 +1,7 @@
 <!-- Footer -->
 <footer>
     <ul class="footer-links">
+        <li><a href="/profielen" class="m-0">Profiles</a> - </li>
         <li><a href="https://18date.net/" target="_blank" class="m-0">18Date</a> - </li>
         <li><a href="https://sex55.net/" target="_blank" class="m-0">Sex55</a> - </li>
         <li><a href="https://shemaledaten.net/" target="_blank" class="m-0">Shemale Daten</a> - </li>

--- a/DC/profielen.php
+++ b/DC/profielen.php
@@ -1,0 +1,143 @@
+<?php
+$base = __DIR__;
+require_once $base . '/includes/utils.php';
+require_once $base . '/includes/site.php';
+
+// ==== CONFIG ====
+$csvPath   = $base . '/data/profielen.csv';
+$delimiter = ';';
+$hasHeader = true;
+$idField   = 'id';
+$nameField = 'name';
+$cityField = 'city';
+$linkField = 'link';
+
+// ==== HELPERS ====
+function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); }
+function csvIterator(string $path, string $delimiter = ',', bool $hasHeader = true): Generator {
+    if (!is_readable($path)) { throw new RuntimeException("CSV not readable: $path"); }
+    $f = new SplFileObject($path, 'r');
+    $f->setFlags(SplFileObject::READ_CSV | SplFileObject::SKIP_EMPTY | SplFileObject::DROP_NEW_LINE);
+    $f->setCsvControl($delimiter);
+
+    $headers = null;
+    foreach ($f as $row) {
+        if ($row === [null] || $row === false) { continue; }
+        if ($headers === null) {
+            if ($hasHeader) {
+                $headers = array_map(function ($h) {
+                    $h = (string) $h;
+                    $h = preg_replace('/^\xEF\xBB\xBF/', '', $h);
+                    return trim($h);
+                }, $row);
+                continue;
+            }
+            $headers = array_map(fn($i) => "col_$i", array_keys($row));
+        }
+        $assoc = [];
+        foreach ($headers as $i => $key) {
+            $assoc[$key] = $row[$i] ?? '';
+        }
+        yield $assoc;
+    }
+}
+
+// ==== LOAD PROFILES ====
+$profiles = [];
+try {
+    foreach (csvIterator($csvPath, $delimiter, $hasHeader) as $rec) {
+        $id = trim((string)($rec[$idField] ?? ''));
+        if ($id === '') {
+            continue;
+        }
+        $profiles[] = $rec;
+    }
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo '<p>Error reading CSV: ' . h($e->getMessage()) . '</p>';
+    exit;
+}
+
+// ==== PAGINATION ====
+$perPage = 500;
+$page    = max(1, (int)($_GET['page'] ?? 1));
+$total   = count($profiles);
+$pages   = (int) ceil($total / $perPage);
+$offset  = ($page - 1) * $perPage;
+$profiles = array_slice($profiles, $offset, $perPage);
+
+$baseUrl  = get_base_url('https://datingcontact.co.uk');
+$canonical = $baseUrl . '/profielen' . ($page > 1 ? '?page=' . $page : '');
+$pageTitle = 'Profiles — Dating Contact';
+$metaRobots = 'index,follow';
+
+$t = [
+    'heading' => 'Profiles',
+    'no_profiles' => 'No profiles found.',
+    'view_profile' => 'View profile',
+    'first' => 'First',
+    'prev' => 'Previous',
+    'page_of' => 'Page %d of %d',
+    'next' => 'Next',
+    'last' => 'Last',
+    'pagination_label' => 'Profiles pagination',
+];
+
+include $base . '/includes/header.php';
+?>
+<div class="container">
+    <div class="jumbotron my-4">
+        <h1><?= $t['heading'] ?></h1>
+
+        <?php if (empty($profiles)): ?>
+            <p><?= $t['no_profiles'] ?></p>
+        <?php else: ?>
+        <?php $chunks = array_chunk($profiles, 250); ?>
+        <div class="row">
+            <?php foreach ($chunks as $chunk): ?>
+            <div class="col-md-6">
+                <ul class="list-unstyled">
+                    <?php foreach ($chunk as $r):
+                        $id   = trim((string)($r[$idField] ?? ''));
+                        if ($id === '') continue;
+                        $name = $r[$nameField] ?? ('Profile ' . $id);
+                        $city = $r[$cityField] ?? '';
+                        $link = $r[$linkField] ?? '';
+                    ?>
+                    <li class="mb-1">
+                        <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>"><?= $t['view_profile'] ?></a>
+                    </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <?php if ($pages > 1): ?>
+    <nav aria-label="<?= $t['pagination_label'] ?>">
+        <?php
+        $prevPage = max(1, $page - 1);
+        $nextPage = min($pages, $page + 1);
+        ?>
+        <ul class="pagination">
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=1"><?= $t['first'] ?></a>
+            </li>
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$prevPage?>"><?= $t['prev'] ?></a>
+            </li>
+            <li class="page-item disabled">
+                <span class="page-link"><?php printf($t['page_of'], $page, $pages); ?></span>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$nextPage?>"><?= $t['next'] ?></a>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$pages?>"><?= $t['last'] ?></a>
+            </li>
+        </ul>
+    </nav>
+    <?php endif; ?>
+    <?php endif; ?>
+</div>
+<?php include $base . '/includes/footer.php'; ?>

--- a/ONL/includes/footer.php
+++ b/ONL/includes/footer.php
@@ -1,7 +1,8 @@
 <!-- Footer -->
 <footer>
-	<ul class="footer-links">
-		<li><a href="https://18date.net/" target="_blank" class="m-0">18Date</a> - </li>
+        <ul class="footer-links">
+                <li><a href="/profielen.php" class="m-0">Profielen</a> - </li>
+                <li><a href="https://18date.net/" target="_blank" class="m-0">18Date</a> - </li>
 		<li><a href="https://sex55.net/" target="_blank" class="m-0">Sex55</a> - </li>
 		<li><a href="https://shemaledaten.net/" target="_blank" class="m-0">Shemale Daten</a> - </li>
 		<li><a href="https://zoekertjesbelgie.be" target="_blank" class="m-0">Zoekertjes België</a> - </li>

--- a/ONL/profielen.php
+++ b/ONL/profielen.php
@@ -1,0 +1,143 @@
+<?php
+$base = __DIR__;
+require_once $base . '/includes/utils.php';
+require_once $base . '/includes/site.php';
+
+// ==== CONFIG ====
+$csvPath   = $base . '/data/profielen.csv';
+$delimiter = ';';
+$hasHeader = true;
+$idField   = 'id';
+$nameField = 'name';
+$cityField = 'city';
+$linkField = 'link';
+
+// ==== HELPERS ====
+function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); }
+function csvIterator(string $path, string $delimiter = ',', bool $hasHeader = true): Generator {
+    if (!is_readable($path)) { throw new RuntimeException("CSV niet leesbaar: $path"); }
+    $f = new SplFileObject($path, 'r');
+    $f->setFlags(SplFileObject::READ_CSV | SplFileObject::SKIP_EMPTY | SplFileObject::DROP_NEW_LINE);
+    $f->setCsvControl($delimiter);
+
+    $headers = null;
+    foreach ($f as $row) {
+        if ($row === [null] || $row === false) { continue; }
+        if ($headers === null) {
+            if ($hasHeader) {
+                $headers = array_map(function ($h) {
+                    $h = (string) $h;
+                    $h = preg_replace('/^\xEF\xBB\xBF/', '', $h);
+                    return trim($h);
+                }, $row);
+                continue;
+            }
+            $headers = array_map(fn($i) => "col_$i", array_keys($row));
+        }
+        $assoc = [];
+        foreach ($headers as $i => $key) {
+            $assoc[$key] = $row[$i] ?? '';
+        }
+        yield $assoc;
+    }
+}
+
+// ==== LOAD PROFILES ====
+$profiles = [];
+try {
+    foreach (csvIterator($csvPath, $delimiter, $hasHeader) as $rec) {
+        $id = trim((string)($rec[$idField] ?? ''));
+        if ($id === '') {
+            continue;
+        }
+        $profiles[] = $rec;
+    }
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo '<p>Fout bij lezen CSV: ' . h($e->getMessage()) . '</p>';
+    exit;
+}
+
+// ==== PAGINATION ====
+$perPage = 500;
+$page    = max(1, (int)($_GET['page'] ?? 1));
+$total   = count($profiles);
+$pages   = (int) ceil($total / $perPage);
+$offset  = ($page - 1) * $perPage;
+$profiles = array_slice($profiles, $offset, $perPage);
+
+$baseUrl  = get_base_url('https://oproepjesnederland.nl');
+$canonical = $baseUrl . '/profielen' . ($page > 1 ? '?page=' . $page : '');
+$pageTitle = 'Profielen — Oproepjes Nederland';
+$metaRobots = 'index,follow';
+
+$t = [
+    'heading' => 'Profielen',
+    'no_profiles' => 'Geen profielen gevonden.',
+    'view_profile' => 'Bekijk profiel',
+    'first' => 'Eerste',
+    'prev' => 'Vorige',
+    'page_of' => 'Pagina %d van %d',
+    'next' => 'Volgende',
+    'last' => 'Laatste',
+    'pagination_label' => 'Profielen paginering',
+];
+
+include $base . '/includes/header.php';
+?>
+<div class="container">
+    <div class="jumbotron my-4">
+        <h1><?= $t['heading'] ?></h1>
+
+        <?php if (empty($profiles)): ?>
+            <p><?= $t['no_profiles'] ?></p>
+        <?php else: ?>
+        <?php $chunks = array_chunk($profiles, 250); ?>
+        <div class="row">
+            <?php foreach ($chunks as $chunk): ?>
+            <div class="col-md-6">
+                <ul class="list-unstyled">
+                    <?php foreach ($chunk as $r):
+                        $id   = trim((string)($r[$idField] ?? ''));
+                        if ($id === '') continue;
+                        $name = $r[$nameField] ?? ('Profiel ' . $id);
+                        $city = $r[$cityField] ?? '';
+                        $link = $r[$linkField] ?? '';
+                    ?>
+                    <li class="mb-1">
+                        <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>"><?= $t['view_profile'] ?></a>
+                    </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <?php if ($pages > 1): ?>
+    <nav aria-label="<?= $t['pagination_label'] ?>">
+        <?php
+        $prevPage = max(1, $page - 1);
+        $nextPage = min($pages, $page + 1);
+        ?>
+        <ul class="pagination">
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=1"><?= $t['first'] ?></a>
+            </li>
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$prevPage?>"><?= $t['prev'] ?></a>
+            </li>
+            <li class="page-item disabled">
+                <span class="page-link"><?php printf($t['page_of'], $page, $pages); ?></span>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$nextPage?>"><?= $t['next'] ?></a>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$pages?>"><?= $t['last'] ?></a>
+            </li>
+        </ul>
+    </nav>
+    <?php endif; ?>
+    <?php endif; ?>
+</div>
+<?php include $base . '/includes/footer.php'; ?>

--- a/S55/includes/footer.php
+++ b/S55/includes/footer.php
@@ -1,7 +1,8 @@
 <!-- Footer -->
 <footer class="bg-dark">
-	<ul class="footer-links">
-		<li><a href="https://18date.net/" target="_blank" class="m-0">18Date</a> - </li>
+        <ul class="footer-links">
+                <li><a href="/profielen.php" class="m-0">Profielen</a> - </li>
+                <li><a href="https://18date.net/" target="_blank" class="m-0">18Date</a> - </li>
 		<li><a href="https://shemaledaten.net/" target="_blank" class="m-0">Shemale Daten</a> - </li>
 		<li><a href="https://oproepjesnederland.nl/" target="_blank" class="m-0">Oproepjes Nederland</a> - </li>
 		<li><a href="https://zoekertjesbelgie.be/" target="_blank" class="m-0">Zoekertjes België</a> - </li>

--- a/S55/profielen.php
+++ b/S55/profielen.php
@@ -1,0 +1,143 @@
+<?php
+$base = __DIR__;
+require_once $base . '/includes/utils.php';
+require_once $base . '/includes/site.php';
+
+// ==== CONFIG ====
+$csvPath   = $base . '/data/profielen.csv';
+$delimiter = ';';
+$hasHeader = true;
+$idField   = 'id';
+$nameField = 'name';
+$cityField = 'city';
+$linkField = 'link';
+
+// ==== HELPERS ====
+function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); }
+function csvIterator(string $path, string $delimiter = ',', bool $hasHeader = true): Generator {
+    if (!is_readable($path)) { throw new RuntimeException("CSV niet leesbaar: $path"); }
+    $f = new SplFileObject($path, 'r');
+    $f->setFlags(SplFileObject::READ_CSV | SplFileObject::SKIP_EMPTY | SplFileObject::DROP_NEW_LINE);
+    $f->setCsvControl($delimiter);
+
+    $headers = null;
+    foreach ($f as $row) {
+        if ($row === [null] || $row === false) { continue; }
+        if ($headers === null) {
+            if ($hasHeader) {
+                $headers = array_map(function ($h) {
+                    $h = (string) $h;
+                    $h = preg_replace('/^\xEF\xBB\xBF/', '', $h);
+                    return trim($h);
+                }, $row);
+                continue;
+            }
+            $headers = array_map(fn($i) => "col_$i", array_keys($row));
+        }
+        $assoc = [];
+        foreach ($headers as $i => $key) {
+            $assoc[$key] = $row[$i] ?? '';
+        }
+        yield $assoc;
+    }
+}
+
+// ==== LOAD PROFILES ====
+$profiles = [];
+try {
+    foreach (csvIterator($csvPath, $delimiter, $hasHeader) as $rec) {
+        $id = trim((string)($rec[$idField] ?? ''));
+        if ($id === '') {
+            continue;
+        }
+        $profiles[] = $rec;
+    }
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo '<p>Fout bij lezen CSV: ' . h($e->getMessage()) . '</p>';
+    exit;
+}
+
+// ==== PAGINATION ====
+$perPage = 500;
+$page    = max(1, (int)($_GET['page'] ?? 1));
+$total   = count($profiles);
+$pages   = (int) ceil($total / $perPage);
+$offset  = ($page - 1) * $perPage;
+$profiles = array_slice($profiles, $offset, $perPage);
+
+$baseUrl  = $BASE_URL;
+$canonical = $baseUrl . '/profielen' . ($page > 1 ? '?page=' . $page : '');
+$pageTitle = 'Profielen — Sex55.net';
+$metaRobots = 'index,follow';
+
+$t = [
+    'heading' => 'Profielen',
+    'no_profiles' => 'Geen profielen gevonden.',
+    'view_profile' => 'Bekijk profiel',
+    'first' => 'Eerste',
+    'prev' => 'Vorige',
+    'page_of' => 'Pagina %d van %d',
+    'next' => 'Volgende',
+    'last' => 'Laatste',
+    'pagination_label' => 'Profielen paginering',
+];
+
+include $base . '/includes/header.php';
+?>
+<div class="container">
+    <div class="jumbotron my-4">
+        <h1><?= $t['heading'] ?></h1>
+
+        <?php if (empty($profiles)): ?>
+            <p><?= $t['no_profiles'] ?></p>
+        <?php else: ?>
+        <?php $chunks = array_chunk($profiles, 250); ?>
+        <div class="row">
+            <?php foreach ($chunks as $chunk): ?>
+            <div class="col-md-6">
+                <ul class="list-unstyled">
+                    <?php foreach ($chunk as $r):
+                        $id   = trim((string)($r[$idField] ?? ''));
+                        if ($id === '') continue;
+                        $name = $r[$nameField] ?? ('Profiel ' . $id);
+                        $city = $r[$cityField] ?? '';
+                        $link = $r[$linkField] ?? '';
+                    ?>
+                    <li class="mb-1">
+                        <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>"><?= $t['view_profile'] ?></a>
+                    </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <?php if ($pages > 1): ?>
+    <nav aria-label="<?= $t['pagination_label'] ?>">
+        <?php
+        $prevPage = max(1, $page - 1);
+        $nextPage = min($pages, $page + 1);
+        ?>
+        <ul class="pagination">
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=1"><?= $t['first'] ?></a>
+            </li>
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$prevPage?>"><?= $t['prev'] ?></a>
+            </li>
+            <li class="page-item disabled">
+                <span class="page-link"><?php printf($t['page_of'], $page, $pages); ?></span>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$nextPage?>"><?= $t['next'] ?></a>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$pages?>"><?= $t['last'] ?></a>
+            </li>
+        </ul>
+    </nav>
+    <?php endif; ?>
+    <?php endif; ?>
+</div>
+<?php include $base . '/includes/footer.php'; ?>

--- a/SD/includes/footer.php
+++ b/SD/includes/footer.php
@@ -1,7 +1,8 @@
 <!-- Footer -->
 <footer class="bg-dark">
-	<ul class="footer-links">
-		<li><a href="https://18date.net/" target="_blank" class="m-0">18Date</a> - </li>
+        <ul class="footer-links">
+                <li><a href="/profielen.php" class="m-0">Profielen</a> - </li>
+                <li><a href="https://18date.net/" target="_blank" class="m-0">18Date</a> - </li>
 		<li><a href="https://sex55.net/" target="_blank" class="m-0">Sex55</a> - </li>
 		<li><a href="https://oproepjesnederland.nl/" target="_blank" class="m-0">Oproepjes Nederland</a> - </li>
 		<li><a href="http://zoekertjesbelgie.be" target="_blank" class="m-0">Zoekertjes België</a> - </li>

--- a/SD/profielen.php
+++ b/SD/profielen.php
@@ -1,0 +1,143 @@
+<?php
+$base = __DIR__;
+require_once $base . '/includes/utils.php';
+require_once $base . '/includes/site.php';
+
+// ==== CONFIG ====
+$csvPath   = $base . '/data/profielen.csv';
+$delimiter = ';';
+$hasHeader = true;
+$idField   = 'id';
+$nameField = 'name';
+$cityField = 'city';
+$linkField = 'link';
+
+// ==== HELPERS ====
+function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); }
+function csvIterator(string $path, string $delimiter = ',', bool $hasHeader = true): Generator {
+    if (!is_readable($path)) { throw new RuntimeException("CSV niet leesbaar: $path"); }
+    $f = new SplFileObject($path, 'r');
+    $f->setFlags(SplFileObject::READ_CSV | SplFileObject::SKIP_EMPTY | SplFileObject::DROP_NEW_LINE);
+    $f->setCsvControl($delimiter);
+
+    $headers = null;
+    foreach ($f as $row) {
+        if ($row === [null] || $row === false) { continue; }
+        if ($headers === null) {
+            if ($hasHeader) {
+                $headers = array_map(function ($h) {
+                    $h = (string) $h;
+                    $h = preg_replace('/^\xEF\xBB\xBF/', '', $h);
+                    return trim($h);
+                }, $row);
+                continue;
+            }
+            $headers = array_map(fn($i) => "col_$i", array_keys($row));
+        }
+        $assoc = [];
+        foreach ($headers as $i => $key) {
+            $assoc[$key] = $row[$i] ?? '';
+        }
+        yield $assoc;
+    }
+}
+
+// ==== LOAD PROFILES ====
+$profiles = [];
+try {
+    foreach (csvIterator($csvPath, $delimiter, $hasHeader) as $rec) {
+        $id = trim((string)($rec[$idField] ?? ''));
+        if ($id === '') {
+            continue;
+        }
+        $profiles[] = $rec;
+    }
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo '<p>Fout bij lezen CSV: ' . h($e->getMessage()) . '</p>';
+    exit;
+}
+
+// ==== PAGINATION ====
+$perPage = 500;
+$page    = max(1, (int)($_GET['page'] ?? 1));
+$total   = count($profiles);
+$pages   = (int) ceil($total / $perPage);
+$offset  = ($page - 1) * $perPage;
+$profiles = array_slice($profiles, $offset, $perPage);
+
+$baseUrl  = $BASE_URL;
+$canonical = $baseUrl . '/profielen' . ($page > 1 ? '?page=' . $page : '');
+$pageTitle = 'Profielen — shemaledaten.net';
+$metaRobots = 'index,follow';
+
+$t = [
+    'heading' => 'Profielen',
+    'no_profiles' => 'Geen profielen gevonden.',
+    'view_profile' => 'Bekijk profiel',
+    'first' => 'Eerste',
+    'prev' => 'Vorige',
+    'page_of' => 'Pagina %d van %d',
+    'next' => 'Volgende',
+    'last' => 'Laatste',
+    'pagination_label' => 'Profielen paginering',
+];
+
+include $base . '/includes/header.php';
+?>
+<div class="container">
+    <div class="jumbotron my-4">
+        <h1><?= $t['heading'] ?></h1>
+
+        <?php if (empty($profiles)): ?>
+            <p><?= $t['no_profiles'] ?></p>
+        <?php else: ?>
+        <?php $chunks = array_chunk($profiles, 250); ?>
+        <div class="row">
+            <?php foreach ($chunks as $chunk): ?>
+            <div class="col-md-6">
+                <ul class="list-unstyled">
+                    <?php foreach ($chunk as $r):
+                        $id   = trim((string)($r[$idField] ?? ''));
+                        if ($id === '') continue;
+                        $name = $r[$nameField] ?? ('Profiel ' . $id);
+                        $city = $r[$cityField] ?? '';
+                        $link = $r[$linkField] ?? '';
+                    ?>
+                    <li class="mb-1">
+                        <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>"><?= $t['view_profile'] ?></a>
+                    </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <?php if ($pages > 1): ?>
+    <nav aria-label="<?= $t['pagination_label'] ?>">
+        <?php
+        $prevPage = max(1, $page - 1);
+        $nextPage = min($pages, $page + 1);
+        ?>
+        <ul class="pagination">
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=1"><?= $t['first'] ?></a>
+            </li>
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$prevPage?>"><?= $t['prev'] ?></a>
+            </li>
+            <li class="page-item disabled">
+                <span class="page-link"><?php printf($t['page_of'], $page, $pages); ?></span>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$nextPage?>"><?= $t['next'] ?></a>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$pages?>"><?= $t['last'] ?></a>
+            </li>
+        </ul>
+    </nav>
+    <?php endif; ?>
+    <?php endif; ?>
+</div>
+<?php include $base . '/includes/footer.php'; ?>

--- a/ZB/includes/footer.php
+++ b/ZB/includes/footer.php
@@ -1,6 +1,7 @@
 <!-- Footer -->
 <footer>
   <ul class="footer-links">
+        <li><a href="/profielen" class="m-0">Profielen</a> - </li>
         <li><a href="https://18date.net/" target="_blank" class="m-0">18Date</a> - </li>
       	<li><a href="https://sex55.net/" target="_blank" class="m-0">Sex55</a> - </li>
       	<li><a href="https://shemaledaten.net/" target="_blank" class="m-0">Shemale Daten</a> - </li>

--- a/ZB/profielen.php
+++ b/ZB/profielen.php
@@ -1,0 +1,143 @@
+<?php
+$base = __DIR__;
+require_once $base . '/includes/utils.php';
+require_once $base . '/includes/site.php';
+
+// ==== CONFIG ====
+$csvPath   = $base . '/data/profielen.csv';
+$delimiter = ';';
+$hasHeader = true;
+$idField   = 'id';
+$nameField = 'name';
+$cityField = 'city';
+$linkField = 'link';
+
+// ==== HELPERS ====
+function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); }
+function csvIterator(string $path, string $delimiter = ',', bool $hasHeader = true): Generator {
+    if (!is_readable($path)) { throw new RuntimeException("CSV niet leesbaar: $path"); }
+    $f = new SplFileObject($path, 'r');
+    $f->setFlags(SplFileObject::READ_CSV | SplFileObject::SKIP_EMPTY | SplFileObject::DROP_NEW_LINE);
+    $f->setCsvControl($delimiter);
+
+    $headers = null;
+    foreach ($f as $row) {
+        if ($row === [null] || $row === false) { continue; }
+        if ($headers === null) {
+            if ($hasHeader) {
+                $headers = array_map(function ($h) {
+                    $h = (string) $h;
+                    $h = preg_replace('/^\xEF\xBB\xBF/', '', $h);
+                    return trim($h);
+                }, $row);
+                continue;
+            }
+            $headers = array_map(fn($i) => "col_$i", array_keys($row));
+        }
+        $assoc = [];
+        foreach ($headers as $i => $key) {
+            $assoc[$key] = $row[$i] ?? '';
+        }
+        yield $assoc;
+    }
+}
+
+// ==== LOAD PROFILES ====
+$profiles = [];
+try {
+    foreach (csvIterator($csvPath, $delimiter, $hasHeader) as $rec) {
+        $id = trim((string)($rec[$idField] ?? ''));
+        if ($id === '') {
+            continue;
+        }
+        $profiles[] = $rec;
+    }
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo '<p>Fout bij lezen CSV: ' . h($e->getMessage()) . '</p>';
+    exit;
+}
+
+// ==== PAGINATION ====
+$perPage = 500;
+$page    = max(1, (int)($_GET['page'] ?? 1));
+$total   = count($profiles);
+$pages   = (int) ceil($total / $perPage);
+$offset  = ($page - 1) * $perPage;
+$profiles = array_slice($profiles, $offset, $perPage);
+
+$baseUrl  = get_base_url('https://zoekertjesbelgie.be');
+$canonical = $baseUrl . '/profielen' . ($page > 1 ? '?page=' . $page : '');
+$pageTitle = 'Profielen — Zoekertjes België';
+$metaRobots = 'index,follow';
+
+$t = [
+    'heading' => 'Profielen',
+    'no_profiles' => 'Geen profielen gevonden.',
+    'view_profile' => 'Bekijk profiel',
+    'first' => 'Eerste',
+    'prev' => 'Vorige',
+    'page_of' => 'Pagina %d van %d',
+    'next' => 'Volgende',
+    'last' => 'Laatste',
+    'pagination_label' => 'Profielen paginering',
+];
+
+include $base . '/includes/header.php';
+?>
+<div class="container">
+    <div class="jumbotron my-4">
+        <h1><?= $t['heading'] ?></h1>
+
+        <?php if (empty($profiles)): ?>
+            <p><?= $t['no_profiles'] ?></p>
+        <?php else: ?>
+        <?php $chunks = array_chunk($profiles, 250); ?>
+        <div class="row">
+            <?php foreach ($chunks as $chunk): ?>
+            <div class="col-md-6">
+                <ul class="list-unstyled">
+                    <?php foreach ($chunk as $r):
+                        $id   = trim((string)($r[$idField] ?? ''));
+                        if ($id === '') continue;
+                        $name = $r[$nameField] ?? ('Profiel ' . $id);
+                        $city = $r[$cityField] ?? '';
+                        $link = $r[$linkField] ?? '';
+                    ?>
+                    <li class="mb-1">
+                        <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>"><?= $t['view_profile'] ?></a>
+                    </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <?php if ($pages > 1): ?>
+    <nav aria-label="<?= $t['pagination_label'] ?>">
+        <?php
+        $prevPage = max(1, $page - 1);
+        $nextPage = min($pages, $page + 1);
+        ?>
+        <ul class="pagination">
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=1"><?= $t['first'] ?></a>
+            </li>
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$prevPage?>"><?= $t['prev'] ?></a>
+            </li>
+            <li class="page-item disabled">
+                <span class="page-link"><?php printf($t['page_of'], $page, $pages); ?></span>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$nextPage?>"><?= $t['next'] ?></a>
+            </li>
+            <li class="page-item<?= $page >= $pages ? ' disabled' : '' ?>">
+                <a class="page-link" href="?page=<?=$pages?>"><?= $t['last'] ?></a>
+            </li>
+        </ul>
+    </nav>
+    <?php endif; ?>
+    <?php endif; ?>
+</div>
+<?php include $base . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add `profielen.php` profile overview for ONL, ZB, 18D, S55, SD and DC
- localize pagination controls and profile link text per site language
- link to profile overviews from each site's footer

## Testing
- `php -l ONL/includes/footer.php`
- `php -l 18D/includes/footer.php`
- `php -l S55/includes/footer.php`
- `php -l SD/includes/footer.php`
- `php -l ZB/includes/footer.php`
- `php -l DC/includes/footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68a57ab8f42c8324bf85d8bacf2e4e16