### PR TITLE
Strip id parameter from ONL profile links

### DIFF
--- a/ONL/profielen.php
+++ b/ONL/profielen.php
@@ -103,6 +103,8 @@ include $base . '/includes/header.php';
                         $name = $r[$nameField] ?? ('Profiel ' . $id);
                         $city = $r[$cityField] ?? '';
                         $link = $r[$linkField] ?? '';
+                        // Strip any id query parameter to match other sites
+                        $link = preg_replace('/\?id=[^&]+/', '', $link);
                     ?>
                     <li class="mb-1">
                         <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>"><?= $t['view_profile'] ?></a>


### PR DESCRIPTION
## Summary
- Remove id query parameter from ONL profile list links to align with other sites

## Testing
- `php -l ONL/profielen.php`


------
https://chatgpt.com/codex/tasks/task_e_68a58002bb408324a975d23f07cf289a