### PR TITLE
Restore id parameter in ONL profile links

### DIFF
--- a/ONL/profielen.php
+++ b/ONL/profielen.php
@@ -103,8 +103,6 @@ include $base . '/includes/header.php';
                         $name = $r[$nameField] ?? ('Profiel ' . $id);
                         $city = $r[$cityField] ?? '';
                         $link = $r[$linkField] ?? '';
-                        // Strip any id query parameter to match other sites
-                        $link = preg_replace('/\?id=[^&]+/', '', $link);
                     ?>
                     <li class="mb-1">
                         <?=h($name)?> - <?=h($city)?> - <a href="<?=h($link)?>"><?= $t['view_profile'] ?></a>


### PR DESCRIPTION
## Summary
- Revert removal of `id` parameter in ONL `profielen.php` so profile links include the identifier like other sites.

## Testing
- `php -l ONL/profielen.php`

------
https://chatgpt.com/codex/tasks/task_e_68a58467f00c83249f092a8dd8bd20f6