### PR TITLE
Fix missing get_base_url helper for dating tips pages

### DIFF
--- a/18D/includes/site.php
+++ b/18D/includes/site.php
@@ -1,6 +1,11 @@
 <?php
 require_once __DIR__ . '/utils.php';
 
+function get_base_url(string $default) {
+    $url = getenv('ONL_BASE_URL');
+    return $url !== false && $url !== '' ? $url : $default;
+}
+
 function configure_error_handling() {
     $appDebug = getenv('APP_DEBUG');
     if (filter_var($appDebug, FILTER_VALIDATE_BOOLEAN)) {

--- a/S55/includes/site.php
+++ b/S55/includes/site.php
@@ -1,6 +1,11 @@
 <?php
 require_once __DIR__ . '/utils.php';
 
+function get_base_url(string $default) {
+    $url = getenv('ONL_BASE_URL');
+    return $url !== false && $url !== '' ? $url : $default;
+}
+
 function configure_error_handling() {
     $appDebug = getenv('APP_DEBUG');
     if (filter_var($appDebug, FILTER_VALIDATE_BOOLEAN)) {

--- a/SD/includes/site.php
+++ b/SD/includes/site.php
@@ -1,6 +1,11 @@
 <?php
 require_once __DIR__ . '/utils.php';
 
+function get_base_url(string $default) {
+    $url = getenv('ONL_BASE_URL');
+    return $url !== false && $url !== '' ? $url : $default;
+}
+
 function configure_error_handling() {
     $appDebug = getenv('APP_DEBUG');
     if (filter_var($appDebug, FILTER_VALIDATE_BOOLEAN)) {


### PR DESCRIPTION
## Summary
- Define `get_base_url` helper in 18D, S55 and SD site utilities
- Prevent fatal error when datingtips.php executes by providing base URL lookup

## Testing
- `php -l 18D/includes/site.php`
- `php -l S55/includes/site.php`
- `php -l SD/includes/site.php`


------
https://chatgpt.com/codex/tasks/task_e_68b05eacd734832490824e08062aac35