### PR TITLE
Fix default dating tips slug

### DIFF
--- a/DC/datingtips.php
+++ b/DC/datingtips.php
@@ -17,14 +17,14 @@ if ($param !== null) {
         return;
     }
 } else {
-    $tipSlug = 'datingtips';
+    $tipSlug = 'dating-tips';
 }
 
 $tips = $datingtips[$tipSlug];
 $metaDescription = $tips['meta'];
 $baseUrl = get_base_url('https://datingcontact.co.uk');
 $canonical = $baseUrl . '/datingtips';
-if ($tipSlug !== 'datingtips') {
+if ($tipSlug !== 'dating-tips') {
     $canonical .= '-' . $tipSlug;
 }
 $pageTitle = $tips['title'] . ' - Dating Contact';


### PR DESCRIPTION
## Summary
- Restore default slug to `dating-tips` to align with tips array keys
- Update canonical link logic to treat `dating-tips` as the default entry

## Testing
- `php -l DC/datingtips.php`


------
https://chatgpt.com/codex/tasks/task_e_68b05eb96bcc8324b52f0f6be835e3cc