### PR TITLE
Guard against unknown dating tip slug

### DIFF
--- a/ZB/datingtips.php
+++ b/ZB/datingtips.php
@@ -19,6 +19,12 @@ if ($param !== null) {
     $tipSlug = 'datingtips';
 }
 
+if (!isset($datingtips[$tipSlug])) {
+    http_response_code(404);
+    include $base . '/404.php';
+    return;
+}
+
 $tips = $datingtips[$tipSlug];
 $metaDescription = $tips['meta'];
 $baseUrl = get_base_url('https://zoekertjesbelgie.be');


### PR DESCRIPTION
## Summary
- Avoid fatal error when visiting `/datingtips` without a valid tip by checking that the slug exists in the tips array

## Testing
- `php -l ZB/datingtips.php`


------
https://chatgpt.com/codex/tasks/task_e_68b05ecfeaa48324acab71ff2549c28a