### PR TITLE
Add meta robots controls and sitemap filtering

### DIFF
--- a/18D/404.php
+++ b/18D/404.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = '404 | Page not found | 18Date.net';
+$metaRobots = 'noindex,follow';
 include $base . '/includes/header.php';
 ?>
 

--- a/18D/generate_sitemap.php
+++ b/18D/generate_sitemap.php
@@ -70,6 +70,8 @@ foreach ($profileUrls as $url) {
     $urls[] = $url;
 }
 
+$urls = exclude_noindex($urls, __DIR__);
+
 $urls = array_filter($urls, static function ($u) {
     return is_string($u) && trim($u) !== '';
 });

--- a/18D/includes/header.php
+++ b/18D/includes/header.php
@@ -30,6 +30,7 @@
   if (!isset($metaDescription) && $generatedMetaDescription) {
     $metaDescription = $generatedMetaDescription;
   }
+  $metaRobots = isset($metaRobots) ? $metaRobots : 'index,follow';
 
 ?>
 
@@ -46,6 +47,7 @@
 ?>
 <meta name="description" content="<?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?>">
 <meta name="author" content="18Date">
+<meta name="robots" content="<?php echo htmlspecialchars($metaRobots, ENT_QUOTES, 'UTF-8'); ?>">
 <link rel="icon" type="image/png" href="img/fav/favicon-96x96.png" sizes="96x96" />
 <link rel="icon" type="image/svg+xml" href="img/fav/favicon.svg" />
 <link rel="shortcut icon" href="img/fav/favicon.ico" />

--- a/18D/includes/sitemap.php
+++ b/18D/includes/sitemap.php
@@ -51,4 +51,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $doc->save($sitemapPath);
     return $added;
 }
+
+function exclude_noindex(array $urls, string $baseDir): array {
+    return array_filter($urls, static function ($url) use ($baseDir) {
+        $path = parse_url($url, PHP_URL_PATH);
+        if ($path === false) {
+            return true;
+        }
+        $path = trim($path, '/');
+        $file = $path === '' ? $baseDir . '/index.php' : $baseDir . '/' . $path . '.php';
+        if (!file_exists($file)) {
+            return true;
+        }
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            return true;
+        }
+        return stripos($contents, 'noindex') === false;
+    });
+}
 ?>

--- a/DC/404.php
+++ b/DC/404.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = '404 | Page not found - Dating Contact';
+$metaRobots = 'noindex,follow';
 include $base . '/includes/header.php';
 ?>
 

--- a/DC/generate_sitemap.php
+++ b/DC/generate_sitemap.php
@@ -49,5 +49,11 @@ foreach ($profilePaths as $url) {
     $urls[] = $url;
 }
 
+$urls = exclude_noindex($urls, __DIR__);
+
+$urls = array_filter($urls, static function ($u) {
+    return is_string($u) && trim($u) !== '';
+});
+
 $added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
 echo "Added $added new URLs to sitemap\n";

--- a/DC/includes/header.php
+++ b/DC/includes/header.php
@@ -23,6 +23,7 @@
       $pageTitle ?? null,
       $companyName
   );
+  $metaRobots = isset($metaRobots) ? $metaRobots : 'index,follow';
 ?>
 <!DOCTYPE html>
 <html lang="en-GB">
@@ -35,6 +36,7 @@
 ?>
 <meta name="description" content="<?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?>">
 <meta name="author" content="Dating Contact">
+<meta name="robots" content="<?php echo htmlspecialchars($metaRobots, ENT_QUOTES, 'UTF-8'); ?>">
 <link rel="apple-touch-icon" sizes="180x180" href="img/fav/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="img/fav/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="img/fav/favicon-16x16.png">

--- a/DC/includes/sitemap.php
+++ b/DC/includes/sitemap.php
@@ -48,4 +48,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $doc->save($sitemapPath);
     return $added;
 }
+
+function exclude_noindex(array $urls, string $baseDir): array {
+    return array_filter($urls, static function ($url) use ($baseDir) {
+        $path = parse_url($url, PHP_URL_PATH);
+        if ($path === false) {
+            return true;
+        }
+        $path = trim($path, '/');
+        $file = $path === '' ? $baseDir . '/index.php' : $baseDir . '/' . $path . '.php';
+        if (!file_exists($file)) {
+            return true;
+        }
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            return true;
+        }
+        return stripos($contents, 'noindex') === false;
+    });
+}
 ?>

--- a/DN/.well-known/404.php
+++ b/DN/.well-known/404.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = '404 | Page not found - Dating Nebenan';
+$metaRobots = 'noindex,follow';
 include $base . '/includes/header.php';
 ?>
 

--- a/DN/.well-known/generate_sitemap.php
+++ b/DN/.well-known/generate_sitemap.php
@@ -61,5 +61,11 @@ foreach ($profilePaths as $url) {
     $urls[] = $url;
 }
 
+$urls = exclude_noindex($urls, __DIR__);
+
+$urls = array_filter($urls, static function ($u) {
+    return is_string($u) && trim($u) !== '';
+});
+
 $added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
 echo "Added $added new URLs to sitemap\n";

--- a/DN/.well-known/includes/header.php
+++ b/DN/.well-known/includes/header.php
@@ -24,6 +24,7 @@
       $pageTitle ?? null,
       $companyName
   );
+  $metaRobots = isset($metaRobots) ? $metaRobots : 'index,follow';
 ?>
 <!DOCTYPE html>
 <html lang="de-DE">
@@ -36,9 +37,7 @@
 ?>
 <meta name="description" content="<?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?>">
 <meta name="author" content="Dating Nebenan">
-<?php if (isset($metaRobots)): ?>
 <meta name="robots" content="<?php echo htmlspecialchars($metaRobots, ENT_QUOTES, 'UTF-8'); ?>">
-<?php endif; ?>
 <link rel="apple-touch-icon" sizes="180x180" href="img/fav/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="img/fav/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="img/fav/favicon-16x16.png">

--- a/DN/.well-known/includes/sitemap.php
+++ b/DN/.well-known/includes/sitemap.php
@@ -48,4 +48,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $doc->save($sitemapPath);
     return $added;
 }
+
+function exclude_noindex(array $urls, string $baseDir): array {
+    return array_filter($urls, static function ($url) use ($baseDir) {
+        $path = parse_url($url, PHP_URL_PATH);
+        if ($path === false) {
+            return true;
+        }
+        $path = trim($path, '/');
+        $file = $path === '' ? $baseDir . '/index.php' : $baseDir . '/' . $path . '.php';
+        if (!file_exists($file)) {
+            return true;
+        }
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            return true;
+        }
+        return stripos($contents, 'noindex') === false;
+    });
+}
 ?>

--- a/DN/.well-known/router.php
+++ b/DN/.well-known/router.php
@@ -83,5 +83,6 @@ if ($path !== '/' && file_exists($phpFile)) {
 }
 
 http_response_code(404);
+$metaRobots = 'noindex,follow';
 include __DIR__ . '/404.php';
 

--- a/DN/404.php
+++ b/DN/404.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = '404 | Page not found - Dating Nebenan';
+$metaRobots = 'noindex,follow';
 include $base . '/includes/header.php';
 ?>
 

--- a/DN/generate_sitemap.php
+++ b/DN/generate_sitemap.php
@@ -61,5 +61,11 @@ foreach ($profilePaths as $url) {
     $urls[] = $url;
 }
 
+$urls = exclude_noindex($urls, __DIR__);
+
+$urls = array_filter($urls, static function ($u) {
+    return is_string($u) && trim($u) !== '';
+});
+
 $added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
 echo "Added $added new URLs to sitemap\n";

--- a/DN/includes/header.php
+++ b/DN/includes/header.php
@@ -24,6 +24,7 @@
       $pageTitle ?? null,
       $companyName
   );
+  $metaRobots = isset($metaRobots) ? $metaRobots : 'index,follow';
 ?>
 <!DOCTYPE html>
 <html lang="de-DE">
@@ -36,9 +37,7 @@
 ?>
 <meta name="description" content="<?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?>">
 <meta name="author" content="Dating Nebenan">
-<?php if (isset($metaRobots)): ?>
 <meta name="robots" content="<?php echo htmlspecialchars($metaRobots, ENT_QUOTES, 'UTF-8'); ?>">
-<?php endif; ?>
 <link rel="apple-touch-icon" sizes="180x180" href="img/fav/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="img/fav/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="img/fav/favicon-16x16.png">

--- a/DN/includes/sitemap.php
+++ b/DN/includes/sitemap.php
@@ -48,4 +48,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $doc->save($sitemapPath);
     return $added;
 }
+
+function exclude_noindex(array $urls, string $baseDir): array {
+    return array_filter($urls, static function ($url) use ($baseDir) {
+        $path = parse_url($url, PHP_URL_PATH);
+        if ($path === false) {
+            return true;
+        }
+        $path = trim($path, '/');
+        $file = $path === '' ? $baseDir . '/index.php' : $baseDir . '/' . $path . '.php';
+        if (!file_exists($file)) {
+            return true;
+        }
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            return true;
+        }
+        return stripos($contents, 'noindex') === false;
+    });
+}
 ?>

--- a/DN/router.php
+++ b/DN/router.php
@@ -83,5 +83,6 @@ if ($path !== '/' && file_exists($phpFile)) {
 }
 
 http_response_code(404);
+$metaRobots = 'noindex,follow';
 include __DIR__ . '/404.php';
 

--- a/ONL/404.php
+++ b/ONL/404.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = '404 | Page not found - Oproepjes Nederland';
+$metaRobots = 'noindex,follow';
 include $base . '/includes/header.php';
 ?>
 

--- a/ONL/generate_sitemap.php
+++ b/ONL/generate_sitemap.php
@@ -49,5 +49,11 @@ foreach ($profilePaths as $url) {
     $urls[] = $url;
 }
 
+$urls = exclude_noindex($urls, __DIR__);
+
+$urls = array_filter($urls, static function ($u) {
+    return is_string($u) && trim($u) !== '';
+});
+
 $added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
 echo "Added $added new URLs to sitemap\n";

--- a/ONL/includes/header.php
+++ b/ONL/includes/header.php
@@ -22,6 +22,7 @@
       $pageTitle ?? null,
       $companyName
   );
+  $metaRobots = isset($metaRobots) ? $metaRobots : 'index,follow';
 ?>
 <!DOCTYPE html>
 <html lang="nl-NL">
@@ -34,6 +35,7 @@
 ?>
 <meta name="description" content="<?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?>">
 <meta name="author" content="Oproepjes Nederland">
+<meta name="robots" content="<?php echo htmlspecialchars($metaRobots, ENT_QUOTES, 'UTF-8'); ?>">
 <link rel="apple-touch-icon" sizes="180x180" href="img/fav/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="img/fav/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="img/fav/favicon-16x16.png">

--- a/ONL/includes/sitemap.php
+++ b/ONL/includes/sitemap.php
@@ -53,4 +53,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $doc->save($sitemapPath);
     return $added;
 }
+
+function exclude_noindex(array $urls, string $baseDir): array {
+    return array_filter($urls, static function ($url) use ($baseDir) {
+        $path = parse_url($url, PHP_URL_PATH);
+        if ($path === false) {
+            return true;
+        }
+        $path = trim($path, '/');
+        $file = $path === '' ? $baseDir . '/index.php' : $baseDir . '/' . $path . '.php';
+        if (!file_exists($file)) {
+            return true;
+        }
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            return true;
+        }
+        return stripos($contents, 'noindex') === false;
+    });
+}
 ?>

--- a/S55/404.php
+++ b/S55/404.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = '404 | Page not found | sex55.net';
+$metaRobots = 'noindex,follow';
 include $base . '/includes/header.php';
 ?>
 

--- a/S55/generate_sitemap.php
+++ b/S55/generate_sitemap.php
@@ -70,6 +70,8 @@ foreach ($profileUrls as $url) {
     $urls[] = $url;
 }
 
+$urls = exclude_noindex($urls, __DIR__);
+
 $urls = array_filter($urls, static function ($u) {
     return is_string($u) && trim($u) !== '';
 });

--- a/S55/includes/header.php
+++ b/S55/includes/header.php
@@ -30,6 +30,7 @@
   if (!isset($metaDescription) && $generatedMetaDescription) {
     $metaDescription = $generatedMetaDescription;
   }
+  $metaRobots = isset($metaRobots) ? $metaRobots : 'index,follow';
 
 ?>
 
@@ -46,6 +47,7 @@
 ?>
 <meta name="description" content="<?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?>">
 <meta name="author" content="Sex55">
+<meta name="robots" content="<?php echo htmlspecialchars($metaRobots, ENT_QUOTES, 'UTF-8'); ?>">
 <link rel="icon" type="image/png" href="img/fav/favicon-96x96.png" sizes="96x96" />
 <link rel="icon" type="image/svg+xml" href="img/fav/favicon.svg" />
 <link rel="shortcut icon" href="img/fav/favicon.ico" />

--- a/S55/includes/sitemap.php
+++ b/S55/includes/sitemap.php
@@ -51,4 +51,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $doc->save($sitemapPath);
     return $added;
 }
+
+function exclude_noindex(array $urls, string $baseDir): array {
+    return array_filter($urls, static function ($url) use ($baseDir) {
+        $path = parse_url($url, PHP_URL_PATH);
+        if ($path === false) {
+            return true;
+        }
+        $path = trim($path, '/');
+        $file = $path === '' ? $baseDir . '/index.php' : $baseDir . '/' . $path . '.php';
+        if (!file_exists($file)) {
+            return true;
+        }
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            return true;
+        }
+        return stripos($contents, 'noindex') === false;
+    });
+}
 ?>

--- a/SD/404.php
+++ b/SD/404.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = '404 | Page not found | shemaledaten.net';
+$metaRobots = 'noindex,follow';
 include $base . '/includes/header.php';
 ?>
 

--- a/SD/generate_sitemap.php
+++ b/SD/generate_sitemap.php
@@ -70,6 +70,8 @@ foreach ($profileUrls as $url) {
     $urls[] = $url;
 }
 
+$urls = exclude_noindex($urls, __DIR__);
+
 $urls = array_filter($urls, static function ($u) {
     return is_string($u) && trim($u) !== '';
 });

--- a/SD/includes/header.php
+++ b/SD/includes/header.php
@@ -30,6 +30,7 @@
   if (!isset($metaDescription) && $generatedMetaDescription) {
     $metaDescription = $generatedMetaDescription;
   }
+  $metaRobots = isset($metaRobots) ? $metaRobots : 'index,follow';
 
 ?>
 
@@ -46,6 +47,7 @@
 ?>
 <meta name="description" content="<?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?>">
 <meta name="author" content="ShemaleDaten">
+<meta name="robots" content="<?php echo htmlspecialchars($metaRobots, ENT_QUOTES, 'UTF-8'); ?>">
 <link rel="icon" type="image/png" href="img/fav/favicon-96x96.png" sizes="96x96" />
 <link rel="icon" type="image/svg+xml" href="img/fav/favicon.svg" />
 <link rel="shortcut icon" href="img/fav/favicon.ico" />

--- a/SD/includes/sitemap.php
+++ b/SD/includes/sitemap.php
@@ -51,4 +51,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $doc->save($sitemapPath);
     return $added;
 }
+
+function exclude_noindex(array $urls, string $baseDir): array {
+    return array_filter($urls, static function ($url) use ($baseDir) {
+        $path = parse_url($url, PHP_URL_PATH);
+        if ($path === false) {
+            return true;
+        }
+        $path = trim($path, '/');
+        $file = $path === '' ? $baseDir . '/index.php' : $baseDir . '/' . $path . '.php';
+        if (!file_exists($file)) {
+            return true;
+        }
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            return true;
+        }
+        return stripos($contents, 'noindex') === false;
+    });
+}
 ?>

--- a/ZB/404.php
+++ b/ZB/404.php
@@ -1,6 +1,7 @@
 <?php
 $base = __DIR__;
 $pageTitle = '404 | Page not found - Zoekertjes België';
+$metaRobots = 'noindex,follow';
 include $base . '/includes/header.php';
 ?>
 

--- a/ZB/generate_sitemap.php
+++ b/ZB/generate_sitemap.php
@@ -49,5 +49,11 @@ foreach ($profilePaths as $url) {
     $urls[] = $url;
 }
 
+$urls = exclude_noindex($urls, __DIR__);
+
+$urls = array_filter($urls, static function ($u) {
+    return is_string($u) && trim($u) !== '';
+});
+
 $added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
 echo "Added $added new URLs to sitemap\n";

--- a/ZB/includes/header.php
+++ b/ZB/includes/header.php
@@ -24,6 +24,7 @@
       $pageTitle ?? null,
       $companyName
   );
+  $metaRobots = isset($metaRobots) ? $metaRobots : 'index,follow';
 ?>
 <!DOCTYPE html>
 <html lang="nl-BE">
@@ -36,6 +37,7 @@
 ?>
 <meta name="description" content="<?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?>">
 <meta name="author" content="Zoekertjes Belgie">
+<meta name="robots" content="<?php echo htmlspecialchars($metaRobots, ENT_QUOTES, 'UTF-8'); ?>">
 <link rel="apple-touch-icon" sizes="180x180" href="img/fav/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="img/fav/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="img/fav/favicon-16x16.png">

--- a/ZB/includes/sitemap.php
+++ b/ZB/includes/sitemap.php
@@ -48,4 +48,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $doc->save($sitemapPath);
     return $added;
 }
+
+function exclude_noindex(array $urls, string $baseDir): array {
+    return array_filter($urls, static function ($url) use ($baseDir) {
+        $path = parse_url($url, PHP_URL_PATH);
+        if ($path === false) {
+            return true;
+        }
+        $path = trim($path, '/');
+        $file = $path === '' ? $baseDir . '/index.php' : $baseDir . '/' . $path . '.php';
+        if (!file_exists($file)) {
+            return true;
+        }
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            return true;
+        }
+        return stripos($contents, 'noindex') === false;
+    });
+}
 ?>


### PR DESCRIPTION
## Summary
- add `$metaRobots` support to site headers with default `index,follow`
- mark 404 and router templates as `noindex,follow`
- filter `noindex` pages from sitemaps

## Testing
- `git status --short | awk '{print $2}' | xargs -n 1 -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68b0650dcf8483248e8901b2451c14b1