### PR TITLE
chore: standardize base URL variable

### DIFF
--- a/18D/includes/header.php
+++ b/18D/includes/header.php
@@ -3,17 +3,17 @@
   include $base . '/includes/nav_items.php';
   // Config is required for API lookups when rendering profile pages
   $config = include_once $base . '/includes/config.php';
-  $BASE_URL = $config['BASE_URL'];
+  $baseUrl = $config['BASE_URL'];
   require_once $base . '/includes/utils.php';
   require_once $base . '/includes/site.php';
 
   configure_error_handling();
 
   $cfg = [
-    'base_url' => $BASE_URL,
+    'base_url' => $baseUrl,
     'site_name' => '18Date.net',
     'default_title' => '18+ Sexdating | 18Date.net',
-    'default_og_image' => $BASE_URL . '/img/fb.png',
+    'default_og_image' => $baseUrl . '/img/fb.png',
     'item_prefix' => 'sexdate',
     'item_remove_regex' => '/^sexdate-/',
     'item_page_title_prefix' => 'Sexdate',
@@ -72,7 +72,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
       <div class="container">
-        <a class="navbar-brand" href="<?php echo rtrim($BASE_URL, '/'); ?>/"><img class="logo" src="img/logo.png" alt="18Date"></a>
+        <a class="navbar-brand" href="<?php echo rtrim($baseUrl, '/'); ?>/"><img class="logo" src="img/logo.png" alt="18Date"></a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">Menu</button>
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <?php include $base . '/includes/nav.php'; ?>

--- a/DN/.well-known/includes/config.php
+++ b/DN/.well-known/includes/config.php
@@ -3,6 +3,7 @@ $baseUrl = getenv('ONL_BASE_URL') ?: 'https://datingnebenan.de';
 $api_url = getenv('BASE_API_URL') ?: 'https://23mlf01ccde23.com';
 
 return [
+    'BASE_URL' => $baseUrl,
     'BASE_API_URL' => $api_url,
     // When APP_DEBUG is set to 'true', development error reporting is enabled
     'DEBUG' => getenv('APP_DEBUG') === 'true',

--- a/DN/.well-known/includes/header.php
+++ b/DN/.well-known/includes/header.php
@@ -15,7 +15,7 @@
   $config = include $base . '/includes/config.php';
 
   configure_error_handling();
-  $baseUrl = get_base_url('https://datingnebenan.de');
+  $baseUrl = get_base_url($config['BASE_URL']);
   list($canonicalUrl, $title) = generate_canonical(
       $baseUrl,
       $config['PROFILE_ENDPOINT'],

--- a/S55/includes/header.php
+++ b/S55/includes/header.php
@@ -3,17 +3,17 @@
   include $base . '/includes/nav_items.php';
   // Config is required for API lookups when rendering profile pages
   $config = include_once $base . '/includes/config.php';
-  $BASE_URL = $config['BASE_URL'];
+  $baseUrl = $config['BASE_URL'];
   require_once $base . '/includes/utils.php';
   require_once $base . '/includes/site.php';
 
   configure_error_handling();
 
   $cfg = [
-    'base_url' => $BASE_URL,
+    'base_url' => $baseUrl,
     'site_name' => 'sex55.net',
     'default_title' => '55+ Sexdating | sex55.net',
-    'default_og_image' => $BASE_URL . '/img/fb.png',
+    'default_og_image' => $baseUrl . '/img/fb.png',
     'item_prefix' => 'sexdate',
     'item_remove_regex' => '/^sexdate-/',
     'item_page_title_prefix' => 'Sexdate',
@@ -72,7 +72,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
       <div class="container">
-        <a class="navbar-brand" href="<?php echo rtrim($BASE_URL, '/'); ?>/"><img class="logo" src="img/logo.png" alt="Sex55.net"></a>
+        <a class="navbar-brand" href="<?php echo rtrim($baseUrl, '/'); ?>/"><img class="logo" src="img/logo.png" alt="Sex55.net"></a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">Menu</button>
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <?php

--- a/SD/includes/header.php
+++ b/SD/includes/header.php
@@ -3,17 +3,17 @@
   include $base . '/includes/nav_items.php';
   // Config is required for API lookups when rendering profile pages
   $config = include_once $base . '/includes/config.php';
-  $BASE_URL = $config['BASE_URL'];
+  $baseUrl = $config['BASE_URL'];
   require_once $base . '/includes/utils.php';
   require_once $base . '/includes/site.php';
 
   configure_error_handling();
 
   $cfg = [
-    'base_url' => $BASE_URL,
+    'base_url' => $baseUrl,
     'site_name' => 'shemaledaten.net',
     'default_title' => 'Shemale Sexdating | shemaledaten.net',
-    'default_og_image' => $BASE_URL . '/img/fb.png',
+    'default_og_image' => $baseUrl . '/img/fb.png',
     'item_prefix' => 'shemale',
     'item_remove_regex' => '/^(?:sexdate|shemale)-/',
     'item_page_title_prefix' => 'Shemale',
@@ -72,7 +72,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
       <div class="container">
-        <a class="navbar-brand" href="<?php echo rtrim($BASE_URL, '/'); ?>/">Shemale Daten</a>
+          <a class="navbar-brand" href="<?php echo rtrim($baseUrl, '/'); ?>/">Shemale Daten</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">Menu</button>
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <?php


### PR DESCRIPTION
## Summary
- unify header templates to use `$baseUrl` consistently
- expose `BASE_URL` key in `.well-known` config and reference it from header

## Testing
- `php -l S55/includes/header.php`
- `php -l 18D/includes/header.php`
- `php -l SD/includes/header.php`
- `php -l DN/.well-known/includes/header.php`
- `php -l DN/.well-known/includes/config.php`


------
https://chatgpt.com/codex/tasks/task_e_68b06fa640b0832481b52f6a921f8978