### PR TITLE
Normalize profile meta descriptions across sites

### DIFF
--- a/18D/includes/site.php
+++ b/18D/includes/site.php
@@ -21,6 +21,14 @@ function configure_error_handling() {
     }
 }
 
+function format_profile_description(string $text) {
+    $text = preg_replace('/\s+/', ' ', trim($text));
+    if (mb_strlen($text) > 160) {
+        $text = mb_substr($text, 0, 159) . '…';
+    }
+    return mb_strlen($text) < 110 ? '' : $text;
+}
+
 function generate_canonical_meta(array $cfg, array $province = []) {
     $base = rtrim($cfg['base_url'], '/');
     $canonical = $base;
@@ -114,7 +122,7 @@ function generate_canonical_meta(array $cfg, array $province = []) {
             }
             $pageTitle = $cfg['profile_title_prefix'] . ' ' . htmlspecialchars($profile_name, ENT_QUOTES, 'UTF-8') . ' | ' . $cfg['site_name'];
             if ($profile_about) {
-                $metaDescription = $profile_about;
+                $metaDescription = format_profile_description($profile_about);
             }
         } else {
             $params = [];

--- a/DC/includes/site.php
+++ b/DC/includes/site.php
@@ -21,6 +21,14 @@ function configure_error_handling() {
     }
 }
 
+function format_profile_description(string $text) {
+    $text = preg_replace('/\s+/', ' ', trim($text));
+    if (mb_strlen($text) > 160) {
+        $text = mb_substr($text, 0, 159) . '…';
+    }
+    return mb_strlen($text) < 110 ? '' : $text;
+}
+
 function generate_canonical_meta(array $cfg, array $province = []) {
     $base = rtrim($cfg['base_url'], '/');
     $canonical = $base;
@@ -114,7 +122,7 @@ function generate_canonical_meta(array $cfg, array $province = []) {
             }
             $pageTitle = $cfg['profile_title_prefix'] . ' ' . htmlspecialchars($profile_name, ENT_QUOTES, 'UTF-8') . ' | ' . $cfg['site_name'];
             if ($profile_about) {
-                $metaDescription = $profile_about;
+                $metaDescription = format_profile_description($profile_about);
             }
         } else {
             $params = [];

--- a/DN/includes/site.php
+++ b/DN/includes/site.php
@@ -21,6 +21,14 @@ function configure_error_handling() {
     }
 }
 
+function format_profile_description(string $text) {
+    $text = preg_replace('/\s+/', ' ', trim($text));
+    if (mb_strlen($text) > 160) {
+        $text = mb_substr($text, 0, 159) . '…';
+    }
+    return mb_strlen($text) < 110 ? '' : $text;
+}
+
 function generate_canonical_meta(array $cfg, array $province = []) {
     $base = rtrim($cfg['base_url'], '/');
     $canonical = $base;
@@ -114,7 +122,7 @@ function generate_canonical_meta(array $cfg, array $province = []) {
             }
             $pageTitle = $cfg['profile_title_prefix'] . ' ' . htmlspecialchars($profile_name, ENT_QUOTES, 'UTF-8') . ' | ' . $cfg['site_name'];
             if ($profile_about) {
-                $metaDescription = $profile_about;
+                $metaDescription = format_profile_description($profile_about);
             }
         } else {
             $params = [];

--- a/ONL/includes/site.php
+++ b/ONL/includes/site.php
@@ -21,6 +21,14 @@ function configure_error_handling() {
     }
 }
 
+function format_profile_description(string $text) {
+    $text = preg_replace('/\s+/', ' ', trim($text));
+    if (mb_strlen($text) > 160) {
+        $text = mb_substr($text, 0, 159) . '…';
+    }
+    return mb_strlen($text) < 110 ? '' : $text;
+}
+
 function generate_canonical_meta(array $cfg, array $province = []) {
     $base = rtrim($cfg['base_url'], '/');
     $canonical = $base;
@@ -114,7 +122,7 @@ function generate_canonical_meta(array $cfg, array $province = []) {
             }
             $pageTitle = $cfg['profile_title_prefix'] . ' ' . htmlspecialchars($profile_name, ENT_QUOTES, 'UTF-8') . ' | ' . $cfg['site_name'];
             if ($profile_about) {
-                $metaDescription = $profile_about;
+                $metaDescription = format_profile_description($profile_about);
             }
         } else {
             $params = [];

--- a/S55/includes/site.php
+++ b/S55/includes/site.php
@@ -21,6 +21,14 @@ function configure_error_handling() {
     }
 }
 
+function format_profile_description(string $text) {
+    $text = preg_replace('/\s+/', ' ', trim($text));
+    if (mb_strlen($text) > 160) {
+        $text = mb_substr($text, 0, 159) . '…';
+    }
+    return mb_strlen($text) < 110 ? '' : $text;
+}
+
 function generate_canonical_meta(array $cfg, array $province = []) {
     $base = rtrim($cfg['base_url'], '/');
     $canonical = $base;
@@ -114,7 +122,7 @@ function generate_canonical_meta(array $cfg, array $province = []) {
             }
             $pageTitle = $cfg['profile_title_prefix'] . ' ' . htmlspecialchars($profile_name, ENT_QUOTES, 'UTF-8') . ' | ' . $cfg['site_name'];
             if ($profile_about) {
-                $metaDescription = $profile_about;
+                $metaDescription = format_profile_description($profile_about);
             }
         } else {
             $params = [];

--- a/SD/includes/site.php
+++ b/SD/includes/site.php
@@ -21,6 +21,14 @@ function configure_error_handling() {
     }
 }
 
+function format_profile_description(string $text) {
+    $text = preg_replace('/\s+/', ' ', trim($text));
+    if (mb_strlen($text) > 160) {
+        $text = mb_substr($text, 0, 159) . '…';
+    }
+    return mb_strlen($text) < 110 ? '' : $text;
+}
+
 function generate_canonical_meta(array $cfg, array $province = []) {
     $base = rtrim($cfg['base_url'], '/');
     $canonical = $base;
@@ -114,7 +122,7 @@ function generate_canonical_meta(array $cfg, array $province = []) {
             }
             $pageTitle = $cfg['profile_title_prefix'] . ' ' . htmlspecialchars($profile_name, ENT_QUOTES, 'UTF-8') . ' | ' . $cfg['site_name'];
             if ($profile_about) {
-                $metaDescription = $profile_about;
+                $metaDescription = format_profile_description($profile_about);
             }
         } else {
             $params = [];

--- a/ZB/includes/site.php
+++ b/ZB/includes/site.php
@@ -21,6 +21,14 @@ function configure_error_handling() {
     }
 }
 
+function format_profile_description(string $text) {
+    $text = preg_replace('/\s+/', ' ', trim($text));
+    if (mb_strlen($text) > 160) {
+        $text = mb_substr($text, 0, 159) . '…';
+    }
+    return mb_strlen($text) < 110 ? '' : $text;
+}
+
 function generate_canonical_meta(array $cfg, array $province = []) {
     $base = rtrim($cfg['base_url'], '/');
     $canonical = $base;
@@ -114,7 +122,7 @@ function generate_canonical_meta(array $cfg, array $province = []) {
             }
             $pageTitle = $cfg['profile_title_prefix'] . ' ' . htmlspecialchars($profile_name, ENT_QUOTES, 'UTF-8') . ' | ' . $cfg['site_name'];
             if ($profile_about) {
-                $metaDescription = $profile_about;
+                $metaDescription = format_profile_description($profile_about);
             }
         } else {
             $params = [];


### PR DESCRIPTION
## Summary
- add `format_profile_description` helper to normalize and trim profile texts with fallback on short descriptions
- apply helper when setting profile meta descriptions across all site variants

## Testing
- `find . -path '*/includes/site.php' -exec php -l {} \;`
- `php -r 'require "ZB/includes/site.php"; $long=str_repeat("Lorem ipsum dolor sit amet, ",8); $out=format_profile_description($long); echo "long: ".mb_strlen($out)."\n"; $medium=str_repeat("word ",25); $out2=format_profile_description($medium); echo "medium: ".mb_strlen($out2)."\n"; $short=str_repeat("short ",5); $default="Zoek en plaats eenvoudig zoekertjes in heel België. Van dating tot vriendschap, ontdek de beste zoekertjes op Zoekertjes België."; $out3=format_profile_description($short); $final=$out3?:$default; echo "short: ".mb_strlen($final)."\n";'`
- `php -r '$_GET["id"]=1; $_SERVER["PHP_SELF"]="profile.php"; $_SERVER["REQUEST_URI"]="/profile.php?id=1"; chdir("ZB"); ob_start(); include "profile.php"; $html=ob_get_clean(); if(preg_match("/<meta name=\"description\" content=\"([^\"]*)\"/",$html,$m)){echo mb_strlen($m[1]),"\n";}'`
- `php -r '$_GET["id"]=2; $_SERVER["PHP_SELF"]="profile.php"; $_SERVER["REQUEST_URI"]="/profile.php?id=2"; chdir("ZB"); ob_start(); include "profile.php"; $html=ob_get_clean(); if(preg_match("/<meta name=\"description\" content=\"([^\"]*)\"/",$html,$m)){echo mb_strlen($m[1]),"\n";}'`


------
https://chatgpt.com/codex/tasks/task_e_68b159bab96883249cf51ef2b07f1ae3